### PR TITLE
Add statistics

### DIFF
--- a/src/api/messages.ts
+++ b/src/api/messages.ts
@@ -1,0 +1,119 @@
+import {
+  BaseGuildTextChannel,
+  ChannelLogsQueryOptions,
+  Message,
+  ThreadChannel
+} from 'discord.js'
+import { MessageFilteringOptions } from './types/message-filtering-options'
+import { pause } from '../core/utils'
+
+const PAGE_SIZE = 100
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+// This may look complicated, but it just checks that the string is plausibly a date in the correct format. It's
+// intended to protect against mistakes during development.
+const DATE_STRING_RE = /^(2\d\d\d-[01]\d-[0123]\d)(?:$|T)/
+
+const getDateString = (timestamp: string | number | Date) => {
+  let normalizedTimestamp = timestamp
+
+  if (typeof normalizedTimestamp === 'number') {
+    normalizedTimestamp = new Date(normalizedTimestamp)
+  }
+
+  if (normalizedTimestamp instanceof Date) {
+    normalizedTimestamp = normalizedTimestamp.toISOString()
+  }
+
+  const dateStringMatch = normalizedTimestamp.match(DATE_STRING_RE)
+
+  if (dateStringMatch) {
+    return dateStringMatch[1]
+  }
+
+  throw new Error(
+    `Could not parse date string for ${typeof timestamp} ${timestamp}`
+  )
+}
+
+const createDateChecks = ({
+  startDay = 0,
+  endDay = 0
+}: MessageFilteringOptions) => {
+  const now = Date.now()
+
+  const [earliestDate, latestDate] = [startDay, endDay].map(day => {
+    // Treat numbers 0 or below as day offsets, rather than epoch times
+    if (typeof day === 'number' && day <= 0) {
+      day = now + day * MS_PER_DAY
+    }
+
+    return getDateString(day)
+  })
+
+  const isTooOld = (message: Message) =>
+    getDateString(message.createdTimestamp) < earliestDate
+  const isTooNew = (message: Message) =>
+    getDateString(message.createdTimestamp) > latestDate
+
+  const isInDateRange = (message: Message) =>
+    !isTooNew(message) && !isTooOld(message)
+
+  return {
+    isTooOld,
+    isTooNew,
+    isInDateRange
+  }
+}
+
+export async function* loadMessagesFor(
+  channel: BaseGuildTextChannel | ThreadChannel,
+  filteringOptions: MessageFilteringOptions = {}
+) {
+  const { isTooOld, isInDateRange } = createDateChecks(filteringOptions)
+
+  let lastMessage = null
+  let queryCount = 1000
+
+  while (true) {
+    const params: ChannelLogsQueryOptions = { limit: PAGE_SIZE }
+
+    if (lastMessage !== null) {
+      params.before = lastMessage.id
+    }
+
+    const pageOfMessages = await channel.messages.fetch(params)
+
+    for (const message of pageOfMessages.values()) {
+      if (
+        isInDateRange(message) &&
+        ['DEFAULT', 'REPLY'].includes(message.type)
+      ) {
+        yield message
+      }
+    }
+
+    lastMessage = pageOfMessages.last()
+
+    if (
+      pageOfMessages.size !== PAGE_SIZE ||
+      !lastMessage ||
+      isTooOld(lastMessage)
+    ) {
+      break
+    }
+
+    --queryCount
+
+    if (queryCount === 0) {
+      throw new Error(
+        `Too many queries, aborting. Channel ${channel.id}, ${JSON.stringify(
+          filteringOptions
+        )}`
+      )
+    }
+
+    // Wait for 50ms between queries to avoid hitting a rate limit
+    await pause(50)
+  }
+}

--- a/src/api/statistics.ts
+++ b/src/api/statistics.ts
@@ -1,0 +1,174 @@
+import { BaseGuildTextChannel, User } from 'discord.js'
+import { MessageFilteringOptions } from './types/message-filtering-options'
+import { fetchLogChannel, loadTextChannels, useThread } from './channels'
+import { loadMessagesFor } from './messages'
+import { Bot } from '../core/bot'
+
+export interface MessageCount {
+  id: string
+  messageCount: number
+  name: string
+}
+
+export async function postCountsAsRanking(
+  bot: Bot,
+  title: string,
+  messageCounts: MessageCount[]
+) {
+  const sorted = [...messageCounts]
+    .filter(({ messageCount }) => messageCount > 0)
+    .sort((a, b) => b.messageCount - a.messageCount)
+
+  if (!sorted.length) {
+    return
+  }
+
+  // Cap at 50. The longest name length shouldn't include names so far down that they won't be shown.
+  sorted.length = Math.min(sorted.length, 50)
+
+  const largestCount = sorted[0].messageCount
+
+  let messageContent = '**' + title + '**\n```\n'
+
+  const longestCountLength = `${largestCount}`.length
+  const longestNameLength = Math.max(...sorted.map(({ name }) => name.length))
+
+  let position = 1
+  const MAX_BAR_SIZE = 30
+
+  for (const { name, messageCount } of sorted) {
+    const paddedPosition = `${position}`.padStart(2, ' ')
+    const paddedCount = `${messageCount}`.padStart(longestCountLength, ' ')
+    const paddedName = `${name}`.padEnd(longestNameLength, ' ')
+
+    const barSize = Math.round((MAX_BAR_SIZE * messageCount) / largestCount)
+
+    const barFill = ''.padStart(barSize, '#').padEnd(MAX_BAR_SIZE, ' ')
+    const bar = barSize ? ` - [${barFill}]` : ''
+
+    messageContent +=
+      `${paddedPosition}. ${paddedCount} - ${paddedName}${bar}`.trimEnd() + '\n'
+
+    // Limit is 2000
+    if (messageContent.length > 1900) {
+      break
+    }
+
+    ++position
+  }
+
+  messageContent += '```'
+
+  const logChannel = await fetchLogChannel(bot)
+
+  const thread = await useThread(logChannel, 'STATISTICS')
+
+  await thread.send({
+    content: messageContent
+  })
+}
+
+export async function loadMessageStatistics(
+  bot: Bot,
+  filteringOptions: MessageFilteringOptions
+) {
+  const textChannels = await loadTextChannels(bot)
+
+  const postCountsByAuthor: Record<string, number> = Object.create(null)
+  const postCountsByChannel: Record<string, number> = Object.create(null)
+  const authors: Record<string, User> = Object.create(null)
+  const channels: Record<string, BaseGuildTextChannel> = Object.create(null)
+
+  let threadCount = 0
+  let activeThreadCount = 0
+  let activeChannelCount = 0
+  let messageCount = 0
+
+  for (const channel of textChannels) {
+    const channelId = channel.id
+    postCountsByChannel[channelId] = 0
+    channels[channelId] = channel
+
+    const { threads: activeThreads } = await channel.threads.fetch()
+    const { threads: archiveThreads } = await channel.threads.fetch({
+      archived: {}
+    })
+
+    threadCount += activeThreads.size + archiveThreads.size
+
+    const threads = [
+      channel,
+      ...activeThreads.values(),
+      ...archiveThreads.values()
+    ]
+
+    let activeChannel = false
+
+    for (const thread of threads) {
+      let activeThread = false
+
+      const asyncMessages = loadMessagesFor(thread, filteringOptions)
+
+      for await (const message of asyncMessages) {
+        const { author } = message
+
+        if (author.bot) {
+          continue
+        }
+
+        const authorId = author.id
+
+        if (!authors[authorId]) {
+          authors[authorId] = author
+          postCountsByAuthor[authorId] = 0
+        }
+
+        ++postCountsByAuthor[authorId]
+        ++postCountsByChannel[channelId]
+        ++messageCount
+        activeChannel = true
+        activeThread = true
+      }
+
+      if (activeThread && thread !== channel) {
+        ++activeThreadCount
+      }
+    }
+
+    if (activeChannel) {
+      ++activeChannelCount
+    }
+  }
+
+  const authorsList: MessageCount[] = Object.keys(authors).map(authorId => {
+    const { username } = authors[authorId]
+
+    return {
+      id: authorId,
+      messageCount: postCountsByAuthor[authorId],
+      name: username
+    }
+  })
+
+  const channelsList: MessageCount[] = Object.keys(channels).map(channelId => {
+    const { name } = channels[channelId]
+
+    return {
+      id: channelId,
+      messageCount: postCountsByChannel[channelId],
+      name
+    }
+  })
+
+  return {
+    users: authorsList,
+    channels: channelsList,
+    totals: {
+      activeTextChannels: activeChannelCount,
+      textChannels: textChannels.length,
+      threads: threadCount,
+      activeThreads: activeThreadCount,
+      messages: messageCount
+    }
+  }
+}

--- a/src/api/types/message-filtering-options.ts
+++ b/src/api/types/message-filtering-options.ts
@@ -1,0 +1,15 @@
+// The startDay and endDay support a variety of formats. In all cases the value is interpreted as a day, not a time,
+// even if the value includes a time. Days are in UTC. Examples of ways to specify days:
+//
+// 0                          - today
+// -1                         - yesterday
+// -7                         - seven days ago
+// 1634027900576              - 2021-10-12
+// "2021-10-12T08:38:20.576Z" - 2021-10-12
+// "2021-10-12"               - 2021-10-12
+// Date.now()                 - today
+// new Date()                 - today
+export interface MessageFilteringOptions {
+  startDay?: number | string | Date
+  endDay?: number | string | Date
+}

--- a/src/features/statistics.ts
+++ b/src/features/statistics.ts
@@ -1,9 +1,35 @@
+import { loadMessageStatistics, postCountsAsRanking } from '../api/statistics'
 import { tasks } from '../core/feature'
+import { logger } from '../core/utils'
 
+// This task generates statistics once per week and posts them to the configured channel
 export default tasks({
   // This time is 2021-10-10 00:10:00.000 UTC, which is a Sunday
   startTime: 1633824600000,
   interval: 'weekly',
 
-  action: async bot => {}
+  action: async bot => {
+    logger.info('Starting weekly statistics generation...')
+
+    // Generates statistics from 28 days ago until yesterday. The range is inclusive.
+    const DAYS = 28
+
+    const { users, channels } = await loadMessageStatistics(bot, {
+      startDay: -DAYS,
+      endDay: -1
+    })
+
+    await postCountsAsRanking(
+      bot,
+      `Posts per channel for the last ${DAYS} days`,
+      channels
+    )
+    await postCountsAsRanking(
+      bot,
+      `Posts per user for the last ${DAYS} days`,
+      users
+    )
+
+    logger.info('Successfully completed weekly statistics generation')
+  }
 })


### PR DESCRIPTION
Statistics are generated once a week, on Sunday at 00:10 UTC.

`src/features/statistics.ts` is the best place to start if you want to understand the code. This is already included in `src/index.ts` as part of the bot skeleton.

There isn't a decent query API available to bots, so the statistics are gathered by fetching all of the messages in each channel and thread for the last 28 days.

The results are output to a thread called `STATISTICS` in the log channel. There are two rankings generated, showing the channels and users ordered by total number of posts.

Some other totals are gathered but aren't currently shown in the output (e.g. total number of messages). They may be included in a future iteration.