### PR TITLE
Add jobs channel checks

### DIFF
--- a/src/api/messages.ts
+++ b/src/api/messages.ts
@@ -1,0 +1,119 @@
+import {
+  BaseGuildTextChannel,
+  ChannelLogsQueryOptions,
+  Message,
+  ThreadChannel
+} from 'discord.js'
+import { MessageFilteringOptions } from './types/message-filtering-options'
+import { pause } from '../core/utils'
+
+const PAGE_SIZE = 100
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+// This may look complicated, but it just checks that the string is plausibly a date in the correct format. It's
+// intended to protect against mistakes during development.
+const DATE_STRING_RE = /^(2\d\d\d-[01]\d-[0123]\d)(?:$|T)/
+
+const getDateString = (timestamp: string | number | Date) => {
+  let normalizedTimestamp = timestamp
+
+  if (typeof normalizedTimestamp === 'number') {
+    normalizedTimestamp = new Date(normalizedTimestamp)
+  }
+
+  if (normalizedTimestamp instanceof Date) {
+    normalizedTimestamp = normalizedTimestamp.toISOString()
+  }
+
+  const dateStringMatch = normalizedTimestamp.match(DATE_STRING_RE)
+
+  if (dateStringMatch) {
+    return dateStringMatch[1]
+  }
+
+  throw new Error(
+    `Could not parse date string for ${typeof timestamp} ${timestamp}`
+  )
+}
+
+const createDateChecks = ({
+  startDay = 0,
+  endDay = 0
+}: MessageFilteringOptions) => {
+  const now = Date.now()
+
+  const [earliestDate, latestDate] = [startDay, endDay].map(day => {
+    // Treat numbers 0 or below as day offsets, rather than epoch times
+    if (typeof day === 'number' && day <= 0) {
+      day = now + day * MS_PER_DAY
+    }
+
+    return getDateString(day)
+  })
+
+  const isTooOld = (message: Message) =>
+    getDateString(message.createdTimestamp) < earliestDate
+  const isTooNew = (message: Message) =>
+    getDateString(message.createdTimestamp) > latestDate
+
+  const isInDateRange = (message: Message) =>
+    !isTooNew(message) && !isTooOld(message)
+
+  return {
+    isTooOld,
+    isTooNew,
+    isInDateRange
+  }
+}
+
+export async function* loadMessagesFor(
+  channel: BaseGuildTextChannel | ThreadChannel,
+  filteringOptions: MessageFilteringOptions = {}
+) {
+  const { isTooOld, isInDateRange } = createDateChecks(filteringOptions)
+
+  let lastMessage = null
+  let queryCount = 1000
+
+  while (true) {
+    const params: ChannelLogsQueryOptions = { limit: PAGE_SIZE }
+
+    if (lastMessage !== null) {
+      params.before = lastMessage.id
+    }
+
+    const pageOfMessages = await channel.messages.fetch(params)
+
+    for (const message of pageOfMessages.values()) {
+      if (
+        isInDateRange(message) &&
+        ['DEFAULT', 'REPLY'].includes(message.type)
+      ) {
+        yield message
+      }
+    }
+
+    lastMessage = pageOfMessages.last()
+
+    if (
+      pageOfMessages.size !== PAGE_SIZE ||
+      !lastMessage ||
+      isTooOld(lastMessage)
+    ) {
+      break
+    }
+
+    --queryCount
+
+    if (queryCount === 0) {
+      throw new Error(
+        `Too many queries, aborting. Channel ${channel.id}, ${JSON.stringify(
+          filteringOptions
+        )}`
+      )
+    }
+
+    // Wait for 50ms between queries to avoid hitting a rate limit
+    await pause(50)
+  }
+}

--- a/src/api/types/message-filtering-options.ts
+++ b/src/api/types/message-filtering-options.ts
@@ -1,0 +1,15 @@
+// The startDay and endDay support a variety of formats. In all cases the value is interpreted as a day, not a time,
+// even if the value includes a time. Days are in UTC. Examples of ways to specify days:
+//
+// 0                          - today
+// -1                         - yesterday
+// -7                         - seven days ago
+// 1634027900576              - 2021-10-12
+// "2021-10-12T08:38:20.576Z" - 2021-10-12
+// "2021-10-12"               - 2021-10-12
+// Date.now()                 - today
+// new Date()                 - today
+export interface MessageFilteringOptions {
+  startDay?: number | string | Date
+  endDay?: number | string | Date
+}

--- a/src/features/jobs-channel.ts
+++ b/src/features/jobs-channel.ts
@@ -1,0 +1,135 @@
+import { Message, MessageEmbedOptions, TextChannel } from 'discord.js'
+import { fetchLogChannel, useThread } from '../api/channels'
+import { loadMessagesFor } from '../api/messages'
+import { Bot } from '../core/bot'
+import { events } from '../core/feature'
+
+const messageCache = new Map<string, Message>()
+
+async function updateMessageCache(channel: TextChannel) {
+  if (!messageCache.size) {
+    const asyncMessages = loadMessagesFor(channel, { startDay: -7 })
+    const messages = []
+
+    for await (const message of asyncMessages) {
+      if (!message.author.bot && message.type === 'DEFAULT') {
+        messages.push(message)
+      }
+    }
+
+    // This extra step is to mitigate problems arising from the race condition that could occur if two messages
+    // come in at roughly the same time, potentially leading to the loading process running twice
+    for (const message of messages) {
+      messageCache.set(message.id, message)
+    }
+  }
+
+  const cutOffTime = Date.now() - 7 * 24 * 60 * 60 * 1000
+
+  for (const message of messageCache.values()) {
+    if (message.createdTimestamp < cutOffTime) {
+      messageCache.delete(message.id)
+    }
+  }
+}
+
+const formatDuration = (duration: number) => {
+  if (duration < 60) {
+    return duration + 's'
+  }
+
+  duration /= 60
+
+  if (duration < 60) {
+    return Math.floor(duration) + 'm'
+  }
+
+  duration /= 60
+
+  if (duration < 24) {
+    return Math.floor(duration) + 'h'
+  }
+
+  const days = Math.floor(duration / 24)
+
+  return days + 'd, ' + Math.floor(duration - days * 24) + 'h'
+}
+
+const postLogMessage = async (
+  bot: Bot,
+  messages: Message[],
+  reason: string
+) => {
+  const logChannel = await fetchLogChannel(bot)
+
+  // Use the last message as the reference point as that's the one that triggered the violation
+  const message = messages[messages.length - 1]
+  const time = message.createdTimestamp
+
+  const messageList = messages.slice(-20).map(msg => {
+    const timeDifference = Math.round((time - msg.createdTimestamp) / 1000)
+    return `:small_orange_diamond: [${formatDuration(timeDifference)} ago](${
+      msg.url
+    })`
+  })
+
+  const embed: MessageEmbedOptions = {
+    color: '#fcc419',
+    author: {
+      name: message.author.tag,
+      icon_url: message.author.displayAvatarURL()
+    },
+    title: reason,
+    description: messageList.join('\n'),
+    timestamp: new Date(),
+    footer: {
+      text: `User ID: ${message.author.id}`
+    }
+  }
+
+  const thread = await useThread(logChannel, 'JOBS_MODERATION')
+
+  await thread.send({ embeds: [embed] })
+}
+
+export default events({
+  async messageCreate(bot, message) {
+    // Ignore bots and replies
+    if (message.author.bot || message.type !== 'DEFAULT') {
+      return
+    }
+
+    const channel = message.channel
+
+    if (
+      channel.type !== 'GUILD_TEXT' ||
+      channel.name.toLowerCase() !== 'jobs'
+    ) {
+      return
+    }
+
+    await updateMessageCache(channel)
+
+    messageCache.set(message.id, message)
+
+    const matches = [message]
+    const authorId = message.author.id
+    const timestamp = message.createdTimestamp
+
+    for (const cachedMessage of messageCache.values()) {
+      // The timestamp check stops the message matching itself, or messages posted while populating the cache
+      if (
+        cachedMessage.author.id === authorId &&
+        cachedMessage.createdTimestamp < timestamp
+      ) {
+        matches.push(cachedMessage)
+      }
+    }
+
+    if (matches.length > 1) {
+      matches.sort((a, b) => a.createdTimestamp - b.createdTimestamp)
+
+      await postLogMessage(bot, matches, 'Multiple messages within 7 days')
+    }
+  }
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { fetchLogChannel } from './api/channels'
 import { BotBuilder } from './core/bot'
 import { logger } from './core/utils'
 import deletedMessageLog from './features/deleted-message-log'
+import jobsChannel from './features/jobs-channel'
 import ping from './features/ping'
 import statistics from './features/statistics'
 import { getConfig } from './fs/config'
@@ -20,6 +21,7 @@ const init = async () => {
 
   const bot = await builder
     .use(deletedMessageLog)
+    .use(jobsChannel)
     .use(ping)
     .use(statistics)
     .init()


### PR DESCRIPTION
This feature checks for multiple posts from the same user in the `jobs` channel within 7 days. Replies to other messages are ignored.

This is similar to the spam filter, but the need to check messages for 7 days is a significant difference. The spam filter only retains messages for a few minutes, and if the bot is restarted it will just forget them. This check needs to load all messages for the last 7 days after a restart. Nevertheless, some of the code is very similar to the spam filter.

Unlike the spam filter, deleting a message does not remove it from the bot's list. A deleted job post still counts as a job post.

The files `src/api/messages.ts` and `src/api/types/message-filtering-options.ts` are shared with the statistics feature. It may seem like overkill in the context of this feature, but it does what we need and it's effectively free to reuse it.

Duplicate messages are reported in the `JOBS_MODERATION` thread, with a time difference between the messages and links to the original messages. It still needs a human to do something about the posts, the bot just logs them.