### PR TITLE
Add instruction-message feature

### DIFF
--- a/src/features/instruction-message.ts
+++ b/src/features/instruction-message.ts
@@ -1,0 +1,104 @@
+import { Message, MessageEmbedOptions, TextChannel } from 'discord.js'
+import { events } from '../core/feature'
+import { debounce, withErrorLogging } from '../core/utils'
+
+// This is used as a way to identify which message to delete. It doesn't use the 'usual' #fcc419, helping to ensure we
+// don't accidentally delete a different message. Checking the message text would make it more difficult to change.
+const embedColor = '#fcc418'
+
+const createInstructionMessage = (channelName: string, messageText: string) => {
+  let lastMessage: Message | null = null
+
+  const repostMessage = async (channel: TextChannel) => {
+    let messageToDelete = lastMessage
+    lastMessage = null
+
+    if (messageToDelete && messageToDelete.deleted) {
+      messageToDelete = null
+    }
+
+    if (!messageToDelete) {
+      const recentMessages = await channel.messages.fetch({ limit: 100 })
+      const botUserId = channel.client.user?.id
+
+      for (const message of recentMessages.values()) {
+        if (message.author.id === botUserId && message.deletable) {
+          const embeds = message.embeds
+
+          if (
+            embeds &&
+            embeds.length === 1 &&
+            embeds[0].hexColor === embedColor
+          ) {
+            messageToDelete = message
+            break
+          }
+        }
+      }
+    }
+
+    const embed: MessageEmbedOptions = {
+      color: embedColor,
+      description: messageText
+    }
+
+    const postNewMessage = async () => {
+      lastMessage = await channel.send({ embeds: [embed] })
+    }
+
+    const promises: Promise<unknown>[] = [postNewMessage()]
+
+    if (messageToDelete) {
+      promises.push(messageToDelete.delete())
+    }
+
+    // For error handling we need to wait for both promises
+    await Promise.all(promises)
+  }
+
+  // Debouncing helps to avoid race conditions if multiple messages come in at the same time
+  const repostMessageDebounced = debounce(
+    withErrorLogging(
+      `Updating #${channelName} instruction message`,
+      repostMessage
+    ),
+    10 * 1000
+  )
+
+  return async (message: Message) => {
+    const channel = message.channel
+
+    if (
+      channel.type !== 'GUILD_TEXT' ||
+      channel.name.toLowerCase() !== channelName ||
+      !channel.viewable
+    ) {
+      return
+    }
+
+    repostMessageDebounced(channel)
+  }
+}
+
+const handlers = [
+  createInstructionMessage(
+    'jobs',
+    ':pushpin: Please read [the pinned message](https://discord.com/channels/325477692906536972/325675277046906881/938461542775685140) before posting in this channel'
+  ),
+  createInstructionMessage(
+    'pinia',
+    ':pushpin: Please read [the pinned message](https://discord.com/channels/325477692906536972/911637879212625971/911643741280956486) before posting in this channel'
+  )
+]
+
+export default events({
+  async messageCreate(bot, message) {
+    if (message.author.id === bot.client.user.id) {
+      return
+    }
+
+    for (const handler of handlers) {
+      await handler(message)
+    }
+  }
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { BotBuilder } from './core/bot'
 import { logger } from './core/utils'
 import checkDiscordInvites from './features/check-discord-invites'
 import deletedMessageLog from './features/deleted-message-log'
+import instructionMessage from './features/instruction-message'
 import jobsChannel from './features/jobs-channel'
 import ping from './features/ping'
 import spamDetection from './features/spam-detection'
@@ -25,6 +26,7 @@ const init = async () => {
   const bot = await builder
     .use(checkDiscordInvites)
     .use(deletedMessageLog)
+    .use(instructionMessage)
     .use(jobsChannel)
     .use(ping)
     .use(spamDetection)


### PR DESCRIPTION
This feature posts an instruction message at the end of a channel. Currently it is hardcoded for the `pinia` and `jobs` channels.

The messages use an 'embed'. This allows them to have a yellow border and proper markdown links. The links are used to link to a pinned message in the relevant channel, which includes a much longer message.

A tricky part of this feature is deleting the previous message when posting a new copy. It's easy when the bot is running, but remembering which message to delete after a restart is not so simple. The bot can post other messages in the same channel (e.g. the quote feature), so it needs to be the correct message. Rather than checking the text, which would make it difficult to change the wording, it checks the color of the border. This is using a subtly different yellow to other features, allowing the bot to identify the correct message. The message also need to satisfy other basic checks, such as being posted by the bot and having a single embed.

The delete/repost process is debounced by 10 seconds. There are several reasons for this, but most important is that it avoids a race condition occurring when two messages come in at roughly the same time, triggering a double delete/repost.