### PR TITLE
Add check for Discord invites

### DIFF
--- a/src/api/invites.ts
+++ b/src/api/invites.ts
@@ -1,0 +1,54 @@
+import { BaseGuildTextChannel, Invite } from 'discord.js'
+import { pause } from '../core/utils'
+
+export async function checkInvitesInChannel(channel: BaseGuildTextChannel) {
+  const pageOfMessages = await channel.messages.fetch({ limit: 100 })
+
+  const messageText = pageOfMessages.map(message => message.content).join('\n')
+
+  const lines = messageText.split('\n')
+
+  const success: { line: string; url: string; invite: Invite }[] = []
+  const failure: { line: string; url: string }[] = []
+
+  const checked = new Set()
+
+  for (const line of lines) {
+    const inviteUrls =
+      line.match(/https:\/\/discord(app)?\.(com|gg)\/[\w\/]+/g) || []
+
+    for (const inviteUrl of inviteUrls) {
+      if (checked.has(inviteUrl)) {
+        continue
+      }
+
+      checked.add(inviteUrl)
+
+      let invite = null
+
+      try {
+        invite = await channel.client.fetchInvite(inviteUrl)
+      } catch (ex) {
+        failure.push({
+          line,
+          url: inviteUrl
+        })
+      }
+
+      if (invite) {
+        success.push({
+          invite,
+          line,
+          url: inviteUrl
+        })
+      }
+
+      await pause(100)
+    }
+  }
+
+  return {
+    success,
+    failure
+  }
+}

--- a/src/features/check-discord-invites.ts
+++ b/src/features/check-discord-invites.ts
@@ -1,0 +1,146 @@
+import { ApplicationCommandOptionType } from 'discord-api-types/v9'
+import { fetchLogChannel, loadTextChannels, useThread } from '../api/channels'
+import { checkInvitesInChannel } from '../api/invites'
+import { feature } from '../core/feature'
+import { logger } from '../core/utils'
+
+const CHANNEL_NAME = 'related-discords'
+
+// This task generates statistics once per week and posts them to the configured channel
+export default feature({
+  commands: {
+    name: 'check-discord-invites',
+    description: 'Check recent Discord invites posted in a channel',
+    roles: 'trusted',
+    hidden: true,
+    options: [
+      {
+        name: 'channel',
+        description: 'Defaults to related-discords',
+        type: ApplicationCommandOptionType.Channel
+      }
+    ],
+    action: async (bot, interaction) => {
+      const channelOption = interaction.options.getChannel('channel')
+
+      const channelName = channelOption ? channelOption.name : CHANNEL_NAME
+
+      const textChannels = await loadTextChannels(bot)
+
+      const channel = textChannels.find(channel => channel.name === channelName)
+
+      if (!channel) {
+        await interaction.reply({
+          content: `Text channel ${channelName} not found`,
+          ephemeral: true
+        })
+        return
+      }
+
+      await interaction.reply({
+        content: `Checking invites in \`#${channelName}\`...`,
+        ephemeral: true
+      })
+
+      const { success, failure } = await checkInvitesInChannel(channel)
+
+      success.sort((a, b) => b.invite.presenceCount - a.invite.presenceCount)
+
+      let message = ''
+
+      if (failure.length) {
+        message += `**${failure.length} invites are invalid**\n`
+        message += failure
+          .map(invite => `:small_orange_diamond: ${invite.url}\n`)
+          .join('')
+      }
+
+      if (success.length) {
+        message += `**${success.length} invites are valid**\n`
+        message += success
+          .map(
+            ({ invite, url }) =>
+              `◈ ${invite.presenceCount} / ${invite.memberCount} - ${url} - #${invite.channel.name} - ${invite.guild?.name}\n`
+          )
+          .join('')
+      }
+
+      if (!message) {
+        message += `No invites found in <#${channel.id}>`
+      }
+
+      const messages = []
+
+      while (message) {
+        const chunkSize = 1950
+        const chunk =
+          message.length < chunkSize
+            ? message
+            : message
+                .slice(0, chunkSize)
+                .split('\n')
+                .slice(0, -1)
+                .join('\n')
+                .trim()
+        messages.push(chunk)
+        message = message.slice(chunk.length).trim()
+      }
+
+      // Embeds are capped at 6000 characters
+      messages.length = Math.min(3, messages.length)
+
+      await interaction.editReply({
+        content: `Discord invites in <#${channel.id}>:`,
+        embeds: messages.map(description => ({
+          description
+        }))
+      })
+    }
+  },
+
+  tasks: {
+    // This time is 2021-10-10 06:00:00.000 UTC
+    startTime: 1633845600000,
+    interval: 'daily',
+    action: async bot => {
+      logger.info('Starting Discord invites check...')
+
+      const textChannels = await loadTextChannels(bot)
+
+      const channel = textChannels.find(
+        channel => channel.name === CHANNEL_NAME
+      )
+
+      if (!channel) {
+        logger.error(`Text channel ${CHANNEL_NAME} not found`)
+        return
+      }
+
+      const { success, failure } = await checkInvitesInChannel(channel)
+
+      if (failure.length) {
+        const logChannel = await fetchLogChannel(bot)
+
+        const thread = await useThread(logChannel, 'MAINTENANCE')
+
+        // TODO: paginate
+        const description = failure
+          .map(({ line }) => `:small_orange_diamond: ${line}`)
+          .join('\n')
+
+        await thread.send({
+          embeds: [
+            {
+              title: 'Expired invites',
+              description
+            }
+          ]
+        })
+      }
+
+      logger.info(
+        `Successfully completed invites check. ${success.length} succeeded, ${failure.length} failed.`
+      )
+    }
+  }
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { fetchLogChannel } from './api/channels'
 import { BotBuilder } from './core/bot'
 import { logger } from './core/utils'
+import checkDiscordInvites from './features/check-discord-invites'
 import deletedMessageLog from './features/deleted-message-log'
 import ping from './features/ping'
 import statistics from './features/statistics'
@@ -19,6 +20,7 @@ const init = async () => {
   const builder = new BotBuilder(config)
 
   const bot = await builder
+    .use(checkDiscordInvites)
     .use(deletedMessageLog)
     .use(ping)
     .use(statistics)


### PR DESCRIPTION
This feature checks the Discord invites in `related-discords`, to ensure they're still valid. Discord provides a specific API for checking invites, so most of the work is extracting them from the channel rather than the checking process itself.

Invites that use redirect URLs are not checked.

The check is run daily at 06:00 UTC and any expired invites are posted in the `MAINTENANCE` thread.

There is also a command, `check-discord-invites`, that can be used to check invites in any channel, so long as the invites are in the last 100 messages. This provides more detailed information about the target server, such as the target channel and how many users are on the server. Currently this command is disabled using `hidden: true`, but it will only be available to trusted users and the response is ephemeral (only visible to that user) anyway.