### PR TITLE
Add the quote feature

### DIFF
--- a/src/features/quote.ts
+++ b/src/features/quote.ts
@@ -1,0 +1,84 @@
+import { ApplicationCommandOptionType } from 'discord-api-types/v9'
+import { BaseGuildTextChannel, MessageEmbedOptions } from 'discord.js'
+import { loadTextChannels } from '../api/channels'
+import { command } from '../core/feature'
+
+const CHANNEL_NAMES = ['welcome', 'related-discords', 'how-to-get-help']
+const channelsCache: BaseGuildTextChannel[] = []
+
+export default command({
+  name: 'quote',
+  roles: 'trusted',
+  description:
+    'Quote a message from #welcome, #related-discords or #how-to-get-help',
+  options: [
+    {
+      name: 'message',
+      description: 'URL or message id of the message to quote',
+      type: ApplicationCommandOptionType.String,
+      required: true
+    },
+    {
+      name: 'text',
+      description: 'Custom text to show before the quote',
+      type: ApplicationCommandOptionType.String
+    }
+  ],
+  action: async (bot, interaction) => {
+    const content = interaction.options.getString('text')
+    const chunks = interaction.options
+      .getString('message', true)
+      .trim()
+      .split('/')
+    const messageId = chunks.pop() || ''
+    const channelId = chunks.pop()
+
+    if (!/^\d+$/.test(messageId)) {
+      return interaction.reply({
+        content: `Failed. The message id could not be parsed.`,
+        ephemeral: true
+      })
+    }
+
+    if (!channelsCache.length) {
+      const channels = await loadTextChannels(bot)
+
+      for (const channel of channels) {
+        if (CHANNEL_NAMES.includes(channel.name)) {
+          channelsCache.push(channel)
+        }
+      }
+    }
+
+    let message = null
+
+    for (const channel of channelsCache) {
+      if (!channelId || channel.id === channelId) {
+        try {
+          message = await channel.messages.fetch(messageId)
+          break
+        } catch {}
+      }
+    }
+
+    if (message) {
+      const messageContent = message.content.replace(/[\u200b\n]+$/, '')
+
+      const embed: MessageEmbedOptions = {
+        color: '#1971c2',
+        description: `**From [#${(message.channel as any).name}](${
+          message.url
+        }):**\n\n${messageContent}`
+      }
+
+      await interaction.reply({ content, embeds: [embed] })
+    } else {
+      await interaction.reply({
+        content: `Failed. The message could not be found. Quoting only supports these channels:\n${channelsCache
+          .map(ch => ':small_blue_diamond: <#' + ch.id + '>')
+          .join('\n')}`,
+        ephemeral: true
+      })
+    }
+  }
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import deletedMessageLog from './features/deleted-message-log'
 import instructionMessage from './features/instruction-message'
 import jobsChannel from './features/jobs-channel'
 import ping from './features/ping'
+import quote from './features/quote'
 import spamDetection from './features/spam-detection'
 import statistics from './features/statistics'
 import updateMessage from './features/update-message'
@@ -29,6 +30,7 @@ const init = async () => {
     .use(instructionMessage)
     .use(jobsChannel)
     .use(ping)
+    .use(quote)
     .use(spamDetection)
     .use(statistics)
     .use(updateMessage)


### PR DESCRIPTION
The quote feature adds the `quote` command. The command will repost the contents of a specific message from `welcome`, `related-discords` or `how-to-get-help`, plus a link to the original message.

The command needs to be passed the message id for the quote. It can also be passed the message URL, which it will parse to get the information it needs. Providing the full URL is slightly more efficient as it also includes the channel information, making it easier to find the relevant message.

The command has a second parameter that allows for a free-form message that is included above the quote. The quote itself is presented as an embed.

Only trusted users currently have access to this command. That can be relaxed if the current design proves stable and useful.

This feature could be made easier to use. In practice only a very small number of messages are regularly quoted, so a shortcut command for those could be provided.