### PR TITLE
Replace tabs with spaces inside string literals

### DIFF
--- a/src/features/deleted-message-log.ts
+++ b/src/features/deleted-message-log.ts
@@ -51,9 +51,9 @@ const logDeletedMessages = async (
         icon_url: author?.displayAvatarURL()
       },
       description: `
-				**Message from <@${author?.id}> deleted in** <#${message.channel.id}>
-				${message.content}
-			`
+        **Message from <@${author?.id}> deleted in** <#${message.channel.id}>
+        ${message.content}
+      `
     })
   } else {
     const joinedMessages = messages
@@ -61,9 +61,9 @@ const logDeletedMessages = async (
       .join('\n')
 
     embed.description = `
-			**${count}** messages deleted in <#${message.channel.id}>
-			${joinedMessages}
-		`
+      **${count}** messages deleted in <#${message.channel.id}>
+      ${joinedMessages}
+    `
   }
 
   await deletedMessagesThread.send({ embeds: [embed] })

--- a/src/features/spam-detection.ts
+++ b/src/features/spam-detection.ts
@@ -67,10 +67,10 @@ const postLogMessage = async (
     },
     title: reason,
     description: `
-			${messageList.join('\n')}
-			-----
-			${message.content}
-		`,
+      ${messageList.join('\n')}
+      -----
+      ${message.content}
+    `,
     timestamp: new Date(),
     footer: {
       text: `User ID: ${message.author.id}`


### PR DESCRIPTION
The automatic formatting should use spaces for indentation, but it missed a few tabs because they're inside string literals. Technically they aren't just indentation, they're part of the string value, but in practice they're just indentation.