### PR TITLE
Add an instruction message for admin-requests

### DIFF
--- a/src/features/instruction-message.ts
+++ b/src/features/instruction-message.ts
@@ -82,6 +82,10 @@ const createInstructionMessage = (channelName: string, messageText: string) => {
 
 const handlers = [
   createInstructionMessage(
+    'admin-requests',
+    ':pushpin: If you want to request a new channel, please read [the pinned message](https://discord.com/channels/325477692906536972/325581214910251011/934292005813624952) first. Thanks!'
+  ),
+  createInstructionMessage(
     'jobs',
     ':pushpin: Please read [the pinned message](https://discord.com/channels/325477692906536972/325675277046906881/938461542775685140) before posting in this channel'
   ),


### PR DESCRIPTION
This PR adds an instruction message to the `#admin-requests` channel, asking people to read the pinned message before requesting a new channel. It's been live for a while.