### PR TITLE
Enable pings for the quote and spam detection features

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -87,6 +87,8 @@ export class BotBuilder {
   async init() {
     const client = new Client({
       intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES],
+
+      // This prevents @ mentions from pinging by default. Individual features can re-enable them if required.
       allowedMentions: {
         repliedUser: false
       }

--- a/src/features/quote.ts
+++ b/src/features/quote.ts
@@ -71,7 +71,13 @@ export default command({
         }):**\n\n${messageContent}`
       }
 
-      await interaction.reply({ content, embeds: [embed] })
+      await interaction.reply({
+        content,
+        embeds: [embed],
+        allowedMentions: {
+          parse: ['users']
+        }
+      })
     } else {
       await interaction.reply({
         content: `Failed. The message could not be found. Quoting only supports these channels:\n${channelsCache

--- a/src/features/spam-detection.ts
+++ b/src/features/spam-detection.ts
@@ -122,9 +122,12 @@ const blockFor = (reason: string) => {
 
         const reportSpamChannel = await fetchReportSpamChannel(bot)
 
-        await reportSpamChannel.send(
-          `User <@${member.id}> has been blocked by the spam filter.`
-        )
+        await reportSpamChannel.send({
+          content: `User <@${member.id}> has been blocked by the spam filter.`,
+          allowedMentions: {
+            users: [member.id]
+          }
+        })
       }
     } else {
       logger.warn(


### PR DESCRIPTION
The configuration in `bot.ts` disables pings by default, so `@` mentions won't ping the mentioned user. I hadn't realised this was happening, as it had been my intention for two of the features to send pings.

It is worth noting that pings will come from the bot, rather than the user who triggered the bot. In practice I don't think this poses any problems in the cases where I have enabled pings. The bot doesn't currently have any elevated permissions in this regard, so it can only ping the same people as normal users.

The quote feature allows the person using the command to send arbitrary text along with the quoted message. Typically this is used to ping someone who broke the rules while quoting the relevant section from `#how-to-get-help`. I've used `parse: ['users']` to allow users to be pinged based on that text. Attempting to ping roles will be ignored.

The spam filter posts a message in `#report-spam` that pings a user when they get blocked. In practice this will rarely matter as the user is a bot and won't react to the ping, but in cases of false alarms it is supposed to attract their attention so they know what happened. For this ping I have used `users: [member.id]`, which is a tighter restriction than `parse: ['users']` as it only allows that one user to be pinged.

This change isn't currently deployed to Vue Land.