### PR TITLE
Add auto-create-threads

### DIFF
--- a/src/features/auto-create-threads.ts
+++ b/src/features/auto-create-threads.ts
@@ -1,0 +1,117 @@
+import {
+  Message,
+  MessageEmbedOptions,
+  TextBasedChannel,
+  TextChannel,
+  ThreadChannel
+} from 'discord.js'
+import { events } from '../core/feature'
+import { logger, pause } from '../core/utils'
+
+const messageText =
+  'This thread has been automatically created for your question. Please post any follow-up messages here, rather than in the main channel.'
+
+const isAutoThreadChannel = (
+  channel: TextBasedChannel
+): channel is TextChannel => {
+  return (
+    channel.type === 'GUILD_TEXT' &&
+    channel.name.toLowerCase() === 'pinia' &&
+    channel.viewable
+  )
+}
+
+const isInfoMessage = (message: Message) => {
+  const botUserId = message.client.user?.id
+
+  const { embeds } = message
+
+  return (
+    message.author.id === botUserId &&
+    message.deletable &&
+    embeds &&
+    embeds.length === 1 &&
+    embeds[0].description === messageText
+  )
+}
+
+const ignoreThreads = new WeakSet<ThreadChannel>()
+
+async function deleteInfoMessage(channel: ThreadChannel) {
+  // If we've already deleted the info message there's no need to do it again
+  if (ignoreThreads.has(channel)) {
+    return
+  }
+
+  ignoreThreads.add(channel)
+
+  const recentMessages = await channel.messages.fetch({ limit: 10 })
+
+  let messageToDelete: Message | null = null
+
+  for (const message of recentMessages.values()) {
+    if (isInfoMessage(message)) {
+      messageToDelete = message
+      break
+    }
+  }
+
+  if (messageToDelete) {
+    await messageToDelete.delete()
+  }
+}
+
+export default events({
+  async messageCreate(bot, message) {
+    if (
+      message.author.bot ||
+      message.author.system ||
+      message.system ||
+      !['DEFAULT', 'REPLY'].includes(message.type)
+    ) {
+      return
+    }
+
+    const { channel } = message
+
+    if (
+      channel.type === 'GUILD_PUBLIC_THREAD' &&
+      channel.parent &&
+      isAutoThreadChannel(channel.parent)
+    ) {
+      await deleteInfoMessage(channel)
+      return
+    }
+
+    if (!isAutoThreadChannel(channel)) {
+      return
+    }
+
+    // If someone creates a thread directly it won't initially be marked as having a thread. In practice, the earlier
+    // checks on the message should stop us getting here anyway in that scenario, which is why we log a warning.
+    await pause(250)
+
+    if (message.hasThread) {
+      logger.warn(
+        `Message ${message.id} in #${channel.name} already has a thread`
+      )
+      return
+    }
+
+    const name =
+      bot.guild.members.resolve(message.author)?.nickname ??
+      message.author.username
+
+    const thread = await message.startThread({
+      autoArchiveDuration: 1440,
+      name
+    })
+
+    const embed: MessageEmbedOptions = {
+      color: '#1971c2',
+      description: messageText
+    }
+
+    await thread.send({ embeds: [embed] })
+  }
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { fetchLogChannel, fetchReportSpamChannel } from './api/channels'
 import { BotBuilder } from './core/bot'
 import { logger } from './core/utils'
+import autoCreateThreads from './features/auto-create-threads'
 import checkDiscordInvites from './features/check-discord-invites'
 import deletedMessageLog from './features/deleted-message-log'
 import instructionMessage from './features/instruction-message'
@@ -25,6 +26,7 @@ const init = async () => {
   const builder = new BotBuilder(config)
 
   const bot = await builder
+    .use(autoCreateThreads)
     .use(checkDiscordInvites)
     .use(deletedMessageLog)
     .use(instructionMessage)


### PR DESCRIPTION
This feature automatically creates threads for any message posted in the `#pinia` channel. It is currently live on Vue Land.

This code is loosely inspired by a similar feature in the Vuetify Discord bot.

When the thread is created it will be named after the user who posted the original message. A message from the bot is posted to the thread explaining what has happened. That message is deleted as soon as another message is posted to the thread.

Users can still create threads directly, in which case the bot won't do anything.