### PR TITLE
Allow a quoted message to be deleted

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -86,7 +86,11 @@ export class BotBuilder {
 
   async init() {
     const client = new Client({
-      intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES],
+      intents: [
+        Intents.FLAGS.GUILDS,
+        Intents.FLAGS.GUILD_MESSAGES,
+        Intents.FLAGS.GUILD_MESSAGE_REACTIONS
+      ],
 
       // This prevents @ mentions from pinging by default. Individual features can re-enable them if required.
       allowedMentions: {

--- a/src/features/quote.ts
+++ b/src/features/quote.ts
@@ -1,90 +1,133 @@
+import consola from 'consola'
 import { ApplicationCommandOptionType } from 'discord-api-types/v9'
-import { BaseGuildTextChannel, MessageEmbedOptions } from 'discord.js'
+import {
+  BaseGuildTextChannel,
+  Message,
+  MessageEmbedOptions,
+  PartialMessage
+} from 'discord.js'
 import { loadTextChannels } from '../api/channels'
-import { command } from '../core/feature'
+import { feature } from '../core/feature'
 
 const CHANNEL_NAMES = ['welcome', 'related-discords', 'how-to-get-help']
 const channelsCache: BaseGuildTextChannel[] = []
 
-export default command({
-  name: 'quote',
-  roles: 'trusted',
-  description:
-    'Quote a message from #welcome, #related-discords or #how-to-get-help',
-  options: [
-    {
-      name: 'message',
-      description: 'URL or message id of the message to quote',
-      type: ApplicationCommandOptionType.String,
-      required: true
-    },
-    {
-      name: 'text',
-      description: 'Custom text to show before the quote',
-      type: ApplicationCommandOptionType.String
-    }
-  ],
-  action: async (bot, interaction) => {
-    const content = interaction.options.getString('text')
-    const chunks = interaction.options
-      .getString('message', true)
-      .trim()
-      .split('/')
-    const messageId = chunks.pop() || ''
-    const channelId = chunks.pop()
+const isMyMessage = (message: Message | PartialMessage) => {
+  const botUserId = message.client.user?.id
+  const messageAuthorId = message.author?.id
 
-    if (!/^\d+$/.test(messageId)) {
-      return interaction.reply({
-        content: `Failed. The message id could not be parsed.`,
-        ephemeral: true
-      })
-    }
+  return messageAuthorId != null && messageAuthorId === botUserId
+}
 
-    if (!channelsCache.length) {
-      const channels = await loadTextChannels(bot)
+export default feature({
+  commands: {
+    name: 'quote',
+    roles: 'trusted',
+    description:
+      'Quote a message from #welcome, #related-discords or #how-to-get-help',
+    options: [
+      {
+        name: 'message',
+        description: 'URL or message id of the message to quote',
+        type: ApplicationCommandOptionType.String,
+        required: true
+      },
+      {
+        name: 'text',
+        description: 'Custom text to show before the quote',
+        type: ApplicationCommandOptionType.String
+      }
+    ],
+    action: async (bot, interaction) => {
+      const content = interaction.options.getString('text')
+      const chunks = interaction.options
+        .getString('message', true)
+        .trim()
+        .split('/')
+      const messageId = chunks.pop() || ''
+      const channelId = chunks.pop()
 
-      for (const channel of channels) {
-        if (CHANNEL_NAMES.includes(channel.name)) {
-          channelsCache.push(channel)
+      if (!/^\d+$/.test(messageId)) {
+        return interaction.reply({
+          content: `Failed. The message id could not be parsed.`,
+          ephemeral: true
+        })
+      }
+
+      if (!channelsCache.length) {
+        const channels = await loadTextChannels(bot)
+
+        for (const channel of channels) {
+          if (CHANNEL_NAMES.includes(channel.name)) {
+            channelsCache.push(channel)
+          }
         }
       }
-    }
 
-    let message = null
+      let message = null
 
-    for (const channel of channelsCache) {
-      if (!channelId || channel.id === channelId) {
-        try {
-          message = await channel.messages.fetch(messageId)
-          break
-        } catch {}
-      }
-    }
-
-    if (message) {
-      const messageContent = message.content.replace(/[\u200b\n]+$/, '')
-
-      const embed: MessageEmbedOptions = {
-        color: '#1971c2',
-        description: `**From [#${(message.channel as any).name}](${
-          message.url
-        }):**\n\n${messageContent}`
-      }
-
-      await interaction.reply({
-        content,
-        embeds: [embed],
-        allowedMentions: {
-          parse: ['users']
+      for (const channel of channelsCache) {
+        if (!channelId || channel.id === channelId) {
+          try {
+            message = await channel.messages.fetch(messageId)
+            break
+          } catch {}
         }
-      })
-    } else {
-      await interaction.reply({
-        content: `Failed. The message could not be found. Quoting only supports these channels:\n${channelsCache
-          .map(ch => ':small_blue_diamond: <#' + ch.id + '>')
-          .join('\n')}`,
-        ephemeral: true
-      })
+      }
+
+      if (message) {
+        const messageContent = message.content.replace(/[\u200b\n]+$/, '')
+
+        const embed: MessageEmbedOptions = {
+          color: '#1971c2',
+          description: `**From [#${(message.channel as any).name}](${
+            message.url
+          }):**\n\n${messageContent}`
+        }
+
+        await interaction.reply({
+          content,
+          embeds: [embed],
+          allowedMentions: {
+            parse: ['users']
+          }
+        })
+      } else {
+        await interaction.reply({
+          content: `Failed. The message could not be found. Quoting only supports these channels:\n${channelsCache
+            .map(ch => ':small_blue_diamond: <#' + ch.id + '>')
+            .join('\n')}`,
+          ephemeral: true
+        })
+      }
+    }
+  },
+
+  events: {
+    async messageReactionAdd(bot, reaction, user) {
+      const { message } = reaction
+      const { interaction } = message
+
+      // Check the reaction is on a quote message
+      if (
+        !interaction ||
+        interaction.commandName !== 'quote' ||
+        !isMyMessage(message)
+      ) {
+        return
+      }
+
+      // Check that the user who added the reaction is the same user who requested the quote
+      if (interaction.user !== user) {
+        return
+      }
+
+      const emojiName = reaction.emoji.name
+
+      if (emojiName && ['🔥', '🗑️', '❌', '💣', '🧨'].includes(emojiName)) {
+        consola.log(`Deleting quoted message for ${user.tag}`)
+        await message.delete()
+      }
     }
   }
 })


### PR DESCRIPTION
When someone requests a quote with `/quote`, the quoted message is posted by the bot, not the original user, so they can't delete it.

This PR allows the message to be deleted by adding a reaction emoji. The reaction must be added by the user that requested the quote, and only 5 emojis will trigger a delete: 🔥, 🗑️, ❌, 💣 and 🧨.

The bot won't receive events related to older messages, so only recently posted quotes can be deleted this way.

The diff looks a mess, but the quote command itself shouldn't have changed. Adding the `messageReactionAdd` event needed an extra wrapper object, which has pushed up all the indentation a level, making it look like everything has changed.