### PR TITLE
Remove uses of the deprecated 'deleted' property

### DIFF
--- a/src/api/channels.ts
+++ b/src/api/channels.ts
@@ -5,6 +5,7 @@ import {
   ThreadAutoArchiveDuration,
   ThreadChannel
 } from 'discord.js'
+import { isDeleted } from './deletion-cache'
 import { Bot } from '../core/bot'
 
 export async function fetchLogChannel(bot: Bot): Promise<TextChannel> {
@@ -75,7 +76,7 @@ const threadCache: Record<string, ThreadChannel> = {}
 export async function getThreadByName(channel: TextChannel, name: string) {
   const thread = threadCache[name]
 
-  if (thread && !thread.deleted) {
+  if (thread && !isDeleted(thread)) {
     return thread
   }
 

--- a/src/api/deletion-cache.ts
+++ b/src/api/deletion-cache.ts
@@ -1,0 +1,30 @@
+import { Message, PartialMessage, ThreadChannel } from 'discord.js'
+import { BotContext } from '../core/bot'
+
+export type Deletable = Message | PartialMessage | ThreadChannel
+
+const deleted = new WeakSet<Deletable>()
+
+export function register(bot: BotContext) {
+  bot.addEvent('messageDelete', (_, message) => {
+    deleted.add(message)
+  })
+
+  bot.addEvent('threadDelete', (_, thread) => {
+    deleted.add(thread)
+  })
+}
+
+export function isDeleted(entity: Deletable) {
+  if ('channel' in entity) {
+    const channel = entity.channel
+
+    // If the channel is missing then it typically means that the message is from a deleted thread. We check the thread
+    // explicitly, but in practice it shouldn't be present on the message anyway.
+    if (!channel || (channel.isThread() && deleted.has(channel))) {
+      return true
+    }
+  }
+
+  return deleted.has(entity)
+}

--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -1,4 +1,5 @@
 import { Awaitable, Client, ClientEvents, Guild, Intents } from 'discord.js'
+import { register } from '../api/deletion-cache'
 import { Command } from './types/command'
 import { Config } from './types/config'
 import CommandManager from './command-manager'
@@ -118,6 +119,8 @@ export class BotBuilder {
       },
       bot
     }
+
+    register(context)
 
     let feature = null
 

--- a/src/features/instruction-message.ts
+++ b/src/features/instruction-message.ts
@@ -1,4 +1,5 @@
 import { Message, MessageEmbedOptions, TextChannel } from 'discord.js'
+import { isDeleted } from '../api/deletion-cache'
 import { events } from '../core/feature'
 import { debounce, withErrorLogging } from '../core/utils'
 
@@ -13,7 +14,7 @@ const createInstructionMessage = (channelName: string, messageText: string) => {
     let messageToDelete = lastMessage
     lastMessage = null
 
-    if (messageToDelete && messageToDelete.deleted) {
+    if (messageToDelete && isDeleted(messageToDelete)) {
       messageToDelete = null
     }
 

--- a/src/features/spam-detection.ts
+++ b/src/features/spam-detection.ts
@@ -5,6 +5,7 @@ import {
   fetchReportSpamChannel,
   useThread
 } from '../api/channels'
+import { isDeleted } from '../api/deletion-cache'
 import { getTrustedRoles } from '../api/roles'
 import { Bot } from '../core/bot'
 import { feature } from '../core/feature'
@@ -378,7 +379,7 @@ export default feature({
 
       const messagesForUser = recentMessages
         .map(({ message }) => message)
-        .filter(msg => !msg.deleted && msg.author.id === message.author.id)
+        .filter(msg => !isDeleted(msg) && msg.author.id === message.author.id)
 
       for (const rule of rules) {
         // We pass the same message twice as some rules need to compare messages


### PR DESCRIPTION
The `deleted` property for messages and threads is deprecated. This PR attempts to replace it with our own cache of deleted stuff.

The cache itself uses a `WeakSet`, so it shouldn't cause the deleted objects to leak.

The `deleted` flag is deprecated because it is too difficult to implement it reliably. For example, a message might be deleted directly, or because a channel is deleted, or a thread, or because a guild is deleted. There are also performance implications and race conditions that lead to the flag sometimes being incorrect.

See: `https://github.com/discordjs/discord.js/issues/7091`

I've only attempted to handle the deletion of messages and threads, as I believe those are the two that impact the correct running of the bot.