### PR TITLE
Don't include voice channels as text channels

### DIFF
--- a/src/api/channels.ts
+++ b/src/api/channels.ts
@@ -62,7 +62,7 @@ export async function loadTextChannelsForGuild(guild: Guild) {
   const textChannels: BaseGuildTextChannel[] = []
 
   channels.forEach(channel => {
-    if (channel.isText() && channel.viewable) {
+    if (channel.isText() && !channel.isVoice() && channel.viewable) {
       textChannels.push(channel)
     }
   })


### PR DESCRIPTION
Voice channels were recently changed to have a built-in text channel. As a result `channel.isText()` now returns `true` for voice channels.

This causes type checks to fail as `VoiceChannel` is not a `BaseGuildTextChannel`, but more importantly it includes the channel in the array returned by `loadTextChannelsForGuild`.

Exactly which channels we do want returned is a bit fuzzy, as Vue Land only uses a subset of the available channel types. For now I'm trying to maintain the old behaviour of this function, whilst also fixing the TS error.