### PR TITLE
Allow an interaction response to be deleted via a reaction

### DIFF
--- a/src/core/bot.ts
+++ b/src/core/bot.ts
@@ -86,7 +86,11 @@ export class BotBuilder {
 
   async init() {
     const client = new Client({
-      intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES],
+      intents: [
+        Intents.FLAGS.GUILDS,
+        Intents.FLAGS.GUILD_MESSAGES,
+        Intents.FLAGS.GUILD_MESSAGE_REACTIONS
+      ],
 
       // This prevents @ mentions from pinging by default. Individual features can re-enable them if required.
       allowedMentions: {

--- a/src/features/reaction-delete-interaction.ts
+++ b/src/features/reaction-delete-interaction.ts
@@ -1,0 +1,41 @@
+import consola from 'consola'
+import { Message, PartialMessage } from 'discord.js'
+import { events } from '../core/feature'
+
+const isMyMessage = (message: Message | PartialMessage) => {
+  const botUserId = message.client.user?.id
+  const messageAuthorId = message.author?.id
+
+  return messageAuthorId != null && messageAuthorId === botUserId
+}
+
+export default events({
+  async messageReactionAdd(bot, reaction, user) {
+    const { message } = reaction
+    const { interaction } = message
+
+    // Check the reaction is on an interaction response from this bot
+    if (
+      !interaction ||
+      interaction.type !== 'APPLICATION_COMMAND' ||
+      !interaction.commandName ||
+      !isMyMessage(message)
+    ) {
+      return
+    }
+
+    // Check that the user who added the reaction is the same user who requested the quote
+    if (interaction.user !== user) {
+      return
+    }
+
+    const emojiName = reaction.emoji.name
+
+    if (emojiName && ['🔥', '🗑️', '❌', '💣', '🧨'].includes(emojiName)) {
+      consola.log(
+        `Deleting /${interaction.commandName} message for ${user.tag}`
+      )
+      await message.delete()
+    }
+  }
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import instructionMessage from './features/instruction-message'
 import jobsChannel from './features/jobs-channel'
 import ping from './features/ping'
 import quote from './features/quote'
+import reactionDeleteInteraction from './features/reaction-delete-interaction'
 import spamDetection from './features/spam-detection'
 import statistics from './features/statistics'
 import updateMessage from './features/update-message'
@@ -33,6 +34,7 @@ const init = async () => {
     .use(jobsChannel)
     .use(ping)
     .use(quote)
+    .use(reactionDeleteInteraction)
     .use(spamDetection)
     .use(statistics)
     .use(updateMessage)


### PR DESCRIPTION
Replaces #17.

When someone requests a quote with `/quote`, the quoted message is posted by the bot, not the original user, so they can't delete it.

This PR allows the message to be deleted by adding a reaction emoji. The reaction must be added by the user that requested the quote, and only 5 emojis will trigger a delete: 🔥, 🗑️, ❌, 💣 and 🧨.

The bot won't receive events related to older messages, so only recently posted quotes can be deleted this way.

This feature isn't limited to the `/quote` command, but currently that is the only command where it can be used in practice. I have work in progress on a `/quote-rules` command, which will also benefit from this deletion feature. It was working on that other command that prompted me to close #17 and implement it this way instead.