### PR TITLE
Add quote-rule command

### DIFF
--- a/src/features/quote-rule.ts
+++ b/src/features/quote-rule.ts
@@ -1,0 +1,115 @@
+import { ApplicationCommandOptionType } from 'discord-api-types/v9'
+import { BaseGuildTextChannel, MessageEmbedOptions } from 'discord.js'
+import { loadTextChannels } from '../api/channels'
+import { command } from '../core/feature'
+import { getAsset } from '../fs/assets'
+
+const RULES_CHANNEL_NAME = 'rules'
+let rulesChannel: BaseGuildTextChannel | undefined = undefined
+
+const numbers = [
+  'one',
+  'two',
+  'three',
+  'four',
+  'five',
+  'six',
+  'seven',
+  'eight',
+  'nine'
+]
+
+export default command(async () => {
+  const rulesText = await getAsset(`${RULES_CHANNEL_NAME}.md`)
+  const lines = rulesText.split('\n').map(line => line.trim())
+
+  const rules: Record<string, string> = Object.create(null)
+  const choices: { name: string; value: string }[] = []
+
+  for (const line of lines) {
+    // Grab the number emoji from the beginning of the line
+    const matches = line.match(/^:([a-z]+):/)
+
+    if (matches) {
+      const numberName = matches[1]
+      const number = numbers.indexOf(numberName) + 1
+
+      if (number) {
+        rules[numberName] = line
+
+        let name = `${number}. ${line}`
+          .replace(/:[a-z]+:/g, '')
+          .replace(/<[^\s>]+>/g, '<...>')
+          .trim()
+
+        if (name.length > 100) {
+          name = name.slice(0, 97).replace(/\S*$/, '') + '...'
+        }
+
+        choices.push({
+          name,
+          value: numberName
+        })
+      }
+    }
+  }
+
+  return {
+    name: 'quote-rule',
+    roles: 'trusted',
+    description: 'Quote a rule from the #rules channel',
+    options: [
+      {
+        name: 'rule',
+        description: 'Rule to quote',
+        type: ApplicationCommandOptionType.String,
+        required: true,
+        choices
+      },
+      {
+        name: 'text',
+        description: 'Custom text to show before the quote',
+        type: ApplicationCommandOptionType.String
+      }
+    ],
+    action: async (bot, interaction) => {
+      const content = interaction.options.getString('text')
+      const numberName = interaction.options.getString('rule', true)
+
+      if (!rulesChannel) {
+        const channels = await loadTextChannels(bot)
+
+        rulesChannel = channels.find(
+          channel => channel.name === RULES_CHANNEL_NAME
+        )
+      }
+
+      if (!rulesChannel) {
+        return interaction.reply({
+          content: `Failed. Channel #${RULES_CHANNEL_NAME} not found.`,
+          ephemeral: true
+        })
+      }
+
+      const rule = rules[numberName]
+
+      if (!rule) {
+        return interaction.reply({
+          content: `Failed. Rule ${numberName} not found`,
+          ephemeral: true
+        })
+      }
+
+      const embed: MessageEmbedOptions = {
+        color: '#1971c2',
+        description: `**From <#${rulesChannel.id}>:**\n\n${rule}`
+      }
+
+      await interaction.reply({
+        content,
+        embeds: [embed],
+        allowedMentions: { parse: ['users'] }
+      })
+    }
+  }
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import instructionMessage from './features/instruction-message'
 import jobsChannel from './features/jobs-channel'
 import ping from './features/ping'
 import quote from './features/quote'
+import quoteRule from './features/quote-rule'
 import reactionDeleteInteraction from './features/reaction-delete-interaction'
 import spamDetection from './features/spam-detection'
 import statistics from './features/statistics'
@@ -34,6 +35,7 @@ const init = async () => {
     .use(jobsChannel)
     .use(ping)
     .use(quote)
+    .use(quoteRule)
     .use(reactionDeleteInteraction)
     .use(spamDetection)
     .use(statistics)


### PR DESCRIPTION
This PR extends #21. That PR should be merged first.

This PR adds a new command, `/quote-rule`, that can be used to quote a specific rule from the `#rules` channel.

The rules all appear in the same message, so the `/quote` command can't be used to pick out an individual rule. `/quote-rule` parses that message and pulls out the 8 individual rules, so they can be quoted individually.

`features.ts` has been changed to add support for registering a command asynchronously. This allows the command to display the parsed rules themselves in the list of options, rather than expecting the user to figure out which rule number they want.