### PR TITLE
Overhaul the loading of text channels

### DIFF
--- a/src/api/invites.ts
+++ b/src/api/invites.ts
@@ -1,7 +1,8 @@
-import { BaseGuildTextChannel, Invite } from 'discord.js'
+import { Invite } from 'discord.js'
+import { MessageableGuildChannel } from './types/channels'
 import { pause } from '../core/utils'
 
-export async function checkInvitesInChannel(channel: BaseGuildTextChannel) {
+export async function checkInvitesInChannel(channel: MessageableGuildChannel) {
   const pageOfMessages = await channel.messages.fetch({ limit: 100 })
 
   const messageText = pageOfMessages.map(message => message.content).join('\n')

--- a/src/api/messages.ts
+++ b/src/api/messages.ts
@@ -1,10 +1,10 @@
 import {
-  BaseGuildTextChannel,
   FetchMessagesOptions,
   Message,
   MessageType,
   ThreadChannel
 } from 'discord.js'
+import { MessageableGuildChannel } from './types/channels'
 import { MessageFilteringOptions } from './types/message-filtering-options'
 import { pause } from '../core/utils'
 
@@ -68,7 +68,7 @@ const createDateChecks = ({
 }
 
 export async function* loadMessagesFor(
-  channel: BaseGuildTextChannel | ThreadChannel,
+  channel: MessageableGuildChannel | ThreadChannel,
   filteringOptions: MessageFilteringOptions = {}
 ) {
   const { isTooOld, isInDateRange } = createDateChecks(filteringOptions)

--- a/src/api/types/channels.ts
+++ b/src/api/types/channels.ts
@@ -1,0 +1,9 @@
+import {
+  ForumChannel,
+  NewsChannel,
+  TextChannel,
+  VoiceChannel
+} from 'discord.js'
+
+export type MessageableGuildChannel = NewsChannel | TextChannel | VoiceChannel
+export type ThreadableGuildChannel = NewsChannel | TextChannel | ForumChannel

--- a/src/features/check-discord-invites.ts
+++ b/src/features/check-discord-invites.ts
@@ -1,5 +1,9 @@
 import { ApplicationCommandOptionType } from 'discord-api-types/v9'
-import { fetchLogChannel, loadTextChannels, useThread } from '../api/channels'
+import {
+  fetchLogChannel,
+  loadMessageableChannels,
+  useThread
+} from '../api/channels'
 import { checkInvitesInChannel } from '../api/invites'
 import { feature } from '../core/feature'
 import { logger } from '../core/utils'
@@ -25,7 +29,7 @@ export default feature({
 
       const channelName = channelOption ? channelOption.name : CHANNEL_NAME
 
-      const textChannels = await loadTextChannels(bot)
+      const textChannels = await loadMessageableChannels(bot)
 
       const channel = textChannels.find(channel => channel.name === channelName)
 
@@ -105,7 +109,7 @@ export default feature({
     action: async bot => {
       logger.info('Starting Discord invites check...')
 
-      const textChannels = await loadTextChannels(bot)
+      const textChannels = await loadMessageableChannels(bot)
 
       const channel = textChannels.find(
         channel => channel.name === CHANNEL_NAME

--- a/src/features/quote-rule.ts
+++ b/src/features/quote-rule.ts
@@ -1,11 +1,12 @@
 import { ApplicationCommandOptionType } from 'discord-api-types/v9'
-import { BaseGuildTextChannel, EmbedBuilder } from 'discord.js'
-import { loadTextChannels } from '../api/channels'
+import { EmbedBuilder } from 'discord.js'
+import { MessageableGuildChannel } from '../api/types/channels'
+import { loadMessageableChannels } from '../api/channels'
 import { command } from '../core/feature'
 import { getAsset } from '../fs/assets'
 
 const RULES_CHANNEL_NAME = 'rules'
-let rulesChannel: BaseGuildTextChannel | undefined = undefined
+let rulesChannel: MessageableGuildChannel | undefined = undefined
 
 const numbers = [
   'one',
@@ -77,7 +78,7 @@ export default command(async () => {
       const numberName = interaction.options.getString('rule', true)
 
       if (!rulesChannel) {
-        const channels = await loadTextChannels(bot)
+        const channels = await loadMessageableChannels(bot)
 
         rulesChannel = channels.find(
           channel => channel.name === RULES_CHANNEL_NAME

--- a/src/features/quote.ts
+++ b/src/features/quote.ts
@@ -1,10 +1,11 @@
 import { ApplicationCommandOptionType } from 'discord-api-types/v9'
-import { BaseGuildTextChannel, EmbedBuilder } from 'discord.js'
-import { loadTextChannels } from '../api/channels'
+import { EmbedBuilder } from 'discord.js'
+import { MessageableGuildChannel } from '../api/types/channels'
+import { loadMessageableChannels } from '../api/channels'
 import { command } from '../core/feature'
 
 const CHANNEL_NAMES = ['welcome', 'related-discords', 'how-to-get-help']
-const channelsCache: BaseGuildTextChannel[] = []
+const channelsCache: MessageableGuildChannel[] = []
 
 export default command({
   name: 'quote',
@@ -41,7 +42,7 @@ export default command({
     }
 
     if (!channelsCache.length) {
-      const channels = await loadTextChannels(bot)
+      const channels = await loadMessageableChannels(bot)
 
       for (const channel of channels) {
         if (CHANNEL_NAMES.includes(channel.name)) {

--- a/src/features/update-message.ts
+++ b/src/features/update-message.ts
@@ -1,6 +1,7 @@
 import { ApplicationCommandOptionType } from 'discord-api-types/v9'
-import { BaseGuildTextChannel, Message } from 'discord.js'
-import { loadTextChannels } from '../api/channels'
+import { Message } from 'discord.js'
+import { MessageableGuildChannel } from '../api/types/channels'
+import { loadMessageableChannels } from '../api/channels'
 import { command } from '../core/feature'
 import { logger } from '../core/utils'
 import { getAsset } from '../fs/assets'
@@ -42,7 +43,7 @@ export default command({
       ephemeral: true
     })
 
-    const textChannels = await loadTextChannels(bot)
+    const textChannels = await loadMessageableChannels(bot)
 
     const channel = textChannels.find(channel => channel.name === channelName)
     const errorMessage = `\`#${channelName}\` could not be updated`
@@ -62,7 +63,7 @@ export default command({
 })
 
 async function updateChannel(
-  channel: BaseGuildTextChannel
+  channel: MessageableGuildChannel
 ): Promise<string | void> {
   const channelName = channel.name
 


### PR DESCRIPTION
There have been some changes to Discord in recent months that make the `loadTextChannels()` function insufficient. Specifically:

* Voice channels now have an associated text chat. A `VoiceChannel` has a `messages` property that behaves much like other text-based channels. However, it doesn't support threads.
* Forum channels do allow threads, but don't allow direct messages to be posted. Annoying, the TS types indicate that forum channels have a `messages` property, even though they don't.

This leads to two different classifications for text channels: those that allow direct text messages and those that allow threads.

I've introduced two new types, `MessageableGuildChannel` and `ThreadableGuildChannel`. These correspond to channels with a `messages` property and channels with a `threads` property respectively. I was going to use some TS `Extract` magic to define them, but the stray `messages` property on `ForumChannel` spoilt that plan, so I've just used an explicit union instead.

I've replaced `loadTextChannels()` with `loadMessageableChannels()` and `loadThreadableChannels()`.

In most cases we only need `loadMessageableChannels()`, but the statistics feature needs to use both and must be careful about differentiating between the two and also handling the overlap.