### PR TITLE
Extract utils for assessing messages

### DIFF
--- a/src/api/statistics.ts
+++ b/src/api/statistics.ts
@@ -12,6 +12,7 @@ import {
 } from './channels'
 import { loadMessagesFor } from './messages'
 import { Bot } from '../core/bot'
+import { isNormalUserMessage } from '../core/utils'
 
 export interface MessageCount {
   id: string
@@ -106,11 +107,11 @@ export async function loadMessageStatistics(
     const asyncMessages = loadMessagesFor(channelOrThread, filteringOptions)
 
     for await (const message of asyncMessages) {
-      const { author } = message
-
-      if (author.bot) {
+      if (!isNormalUserMessage(message)) {
         continue
       }
+
+      const { author } = message
 
       const authorId = author.id
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,5 +1,5 @@
 import consola from 'consola'
-import { Awaitable } from 'discord.js'
+import { Awaitable, Message, MessageType, PartialMessage } from 'discord.js'
 
 export const logger = consola.create({})
 
@@ -46,4 +46,25 @@ export function withErrorLogging<T extends Array<any>>(
       logger.error(`${taskName} failed:`, err)
     }
   }
+}
+
+export function isMyMessage(message: Message | PartialMessage): boolean {
+  const botUserId = message.client.user?.id
+  const messageAuthorId = message.author?.id
+
+  return messageAuthorId != null && messageAuthorId === botUserId
+}
+
+export function isNormalUserMessage(
+  message: Message | PartialMessage
+): boolean {
+  const { author, system, type } = message
+
+  return (
+    !!author &&
+    !author.bot &&
+    !author.system &&
+    !system &&
+    (type === MessageType.Default || type === MessageType.Reply)
+  )
 }

--- a/src/features/auto-create-threads.ts
+++ b/src/features/auto-create-threads.ts
@@ -3,13 +3,12 @@ import {
   EmbedBuilder,
   ForumChannel,
   Message,
-  MessageType,
   TextBasedChannel,
   TextChannel,
   ThreadChannel
 } from 'discord.js'
 import { events } from '../core/feature'
-import { logger, pause } from '../core/utils'
+import { isMyMessage, isNormalUserMessage, logger, pause } from '../core/utils'
 
 const messageText =
   'This thread has been automatically created for your question. Please post any follow-up messages here, rather than in the main channel.'
@@ -26,12 +25,10 @@ const isAutoThreadChannel = (
 }
 
 const isInfoMessage = (message: Message) => {
-  const botUserId = message.client.user?.id
-
   const { embeds } = message
 
   return (
-    message.author.id === botUserId &&
+    isMyMessage(message) &&
     message.deletable &&
     embeds &&
     embeds.length === 1 &&
@@ -67,12 +64,7 @@ async function deleteInfoMessage(channel: ThreadChannel) {
 
 export default events({
   async messageCreate(bot, message) {
-    if (
-      message.author.bot ||
-      message.author.system ||
-      message.system ||
-      ![MessageType.Default, MessageType.Reply].includes(message.type)
-    ) {
+    if (!isNormalUserMessage(message)) {
       return
     }
 

--- a/src/features/instruction-message.ts
+++ b/src/features/instruction-message.ts
@@ -1,7 +1,7 @@
 import { ChannelType, EmbedBuilder, Message, TextChannel } from 'discord.js'
 import { isDeleted } from '../api/deletion-cache'
 import { events } from '../core/feature'
-import { debounce, withErrorLogging } from '../core/utils'
+import { debounce, isMyMessage, withErrorLogging } from '../core/utils'
 
 // This is used as a way to identify which message to delete. It doesn't use the 'usual' #fcc419, helping to ensure we
 // don't accidentally delete a different message. Checking the message text would make it more difficult to change.
@@ -20,10 +20,9 @@ const createInstructionMessage = (channelName: string, messageText: string) => {
 
     if (!messageToDelete) {
       const recentMessages = await channel.messages.fetch({ limit: 100 })
-      const botUserId = channel.client.user?.id
 
       for (const message of recentMessages.values()) {
-        if (message.author.id === botUserId && message.deletable) {
+        if (isMyMessage(message) && message.deletable) {
           const embeds = message.embeds
 
           if (
@@ -97,7 +96,7 @@ const handlers = [
 
 export default events({
   async messageCreate(bot, message) {
-    if (message.author.id === bot.client.user.id) {
+    if (isMyMessage(message)) {
       return
     }
 

--- a/src/features/jobs-channel.ts
+++ b/src/features/jobs-channel.ts
@@ -9,6 +9,7 @@ import { fetchLogChannel, useThread } from '../api/channels'
 import { loadMessagesFor } from '../api/messages'
 import { Bot } from '../core/bot'
 import { events } from '../core/feature'
+import { isNormalUserMessage } from '../core/utils'
 
 const messageCache = new Map<string, Message>()
 
@@ -18,7 +19,10 @@ async function updateMessageCache(channel: TextChannel) {
     const messages = []
 
     for await (const message of asyncMessages) {
-      if (!message.author.bot && message.type === MessageType.Default) {
+      if (
+        isNormalUserMessage(message) &&
+        message.type === MessageType.Default
+      ) {
         messages.push(message)
       }
     }
@@ -100,7 +104,7 @@ const postLogMessage = async (
 export default events({
   async messageCreate(bot, message) {
     // Ignore bots and replies
-    if (message.author.bot || message.type !== MessageType.Default) {
+    if (!isNormalUserMessage(message) || message.type !== MessageType.Default) {
       return
     }
 

--- a/src/features/reaction-delete-interaction.ts
+++ b/src/features/reaction-delete-interaction.ts
@@ -1,14 +1,7 @@
 import consola from 'consola'
 import { InteractionType } from 'discord-api-types/v9'
-import { Message, PartialMessage } from 'discord.js'
 import { events } from '../core/feature'
-
-const isMyMessage = (message: Message | PartialMessage) => {
-  const botUserId = message.client.user?.id
-  const messageAuthorId = message.author?.id
-
-  return messageAuthorId != null && messageAuthorId === botUserId
-}
+import { isMyMessage } from '../core/utils'
 
 export default events({
   async messageReactionAdd(bot, reaction, user) {

--- a/src/features/spam-detection.ts
+++ b/src/features/spam-detection.ts
@@ -1,5 +1,5 @@
 import { ApplicationCommandOptionType } from 'discord-api-types/v9'
-import { EmbedBuilder, Message, MessageType, TextChannel } from 'discord.js'
+import { EmbedBuilder, Message, TextChannel } from 'discord.js'
 import {
   fetchLogChannel,
   fetchReportSpamChannel,
@@ -9,7 +9,7 @@ import { isDeleted } from '../api/deletion-cache'
 import { getTrustedRoles } from '../api/roles'
 import { Bot } from '../core/bot'
 import { feature } from '../core/feature'
-import { logger } from '../core/utils'
+import { isNormalUserMessage, logger } from '../core/utils'
 
 const recentMessages: { message: Message; receivedTime: number }[] = []
 
@@ -354,10 +354,7 @@ export default feature({
 
   events: {
     async messageCreate(bot, message) {
-      if (
-        message.author.bot ||
-        ![MessageType.Default, MessageType.Reply].includes(message.type)
-      ) {
+      if (!isNormalUserMessage(message)) {
         return
       }
 

--- a/src/features/update-message.ts
+++ b/src/features/update-message.ts
@@ -3,7 +3,7 @@ import { Message } from 'discord.js'
 import { MessageableGuildChannel } from '../api/types/channels'
 import { loadMessageableChannels } from '../api/channels'
 import { command } from '../core/feature'
-import { logger } from '../core/utils'
+import { isMyMessage, logger } from '../core/utils'
 import { getAsset } from '../fs/assets'
 
 const CHANNEL_NAMES = [
@@ -80,14 +80,11 @@ async function updateChannel(
   }
 
   const messages: Message[] = []
-  let authorId = null
 
   for (const message of pageOfMessages.values()) {
-    authorId = authorId || message.author.id
-
     // Check some more constraints that confirm the channel is in the state we expect
-    if (message.author.id !== authorId) {
-      logError('The specified channel has messages by multiple authors')
+    if (!isMyMessage(message)) {
+      logError('The specified channel contains messages by another user')
       return
     }
 


### PR DESCRIPTION
This PR introduces two predicate functions for working with messages.

* `isMyMessage` - checks whether a message was sent by this bot.
* `isNormalUserMessage` - checks whether a message is a 'normal' message. Messages sent by bots or automatically created by the system, e.g. when a thread is created, are not counted as normal.

These replace various ad hoc checks throughout the codebase that were effectively checking the same two things in various different ways.