### PR TITLE
Treat Discord invites as spam

### DIFF
--- a/src/features/spam-detection.ts
+++ b/src/features/spam-detection.ts
@@ -29,6 +29,12 @@ const containsBannedTag = (content: string) => {
   return withoutCode.includes('@here') || withoutCode.includes('@everyone')
 }
 
+const containsDiscordInvite = (content: string) => {
+  const withoutCode = stripCode(content)
+
+  return withoutCode.includes('discord.gg/')
+}
+
 const isDuplicate = (content: string, newMessageContent: string) => {
   return content.toLowerCase().trim() === newMessageContent.toLowerCase().trim()
 }
@@ -143,6 +149,7 @@ const blockFor = (reason: string) => {
 
 const blockForBannedTags = blockFor('using banned tags')
 const blockForExcessiveLinks = blockFor('excessive links')
+const blockForExcessiveDiscordInvites = blockFor('excessive Discord invites')
 const blockForExcessiveDuplicates = blockFor('excessive duplicates')
 const blockForExcessivePosts = blockFor('excessive posts')
 
@@ -153,6 +160,10 @@ const logCrossPost = async (bot: Bot, messages: Message[]) => {
 
 const logBannedTags = async (bot: Bot, messages: Message[]) => {
   await postLogMessage(bot, messages, 'Used banned tags')
+}
+
+const logDiscordInvite = async (bot: Bot, messages: Message[]) => {
+  await postLogMessage(bot, messages, 'Discord invite')
 }
 
 interface Rule {
@@ -188,6 +199,12 @@ const rules: Rule[] = [
     timeframe: 60,
     channelCount: 5,
     action: blockForExcessiveLinks
+  },
+  {
+    isBrokenBy: containsDiscordInvite,
+    timeframe: 5,
+    channelCount: 2,
+    action: blockForExcessiveDiscordInvites
   },
   {
     isBrokenBy: isDuplicate,
@@ -236,6 +253,12 @@ const rules: Rule[] = [
     timeframe: 1, // Irrelevant as any use is logged
     channelCount: 1,
     action: logBannedTags
+  },
+  {
+    isBrokenBy: containsDiscordInvite,
+    timeframe: 1, // Irrelevant as any use is logged
+    channelCount: 1,
+    action: logDiscordInvite
   }
 ]
 


### PR DESCRIPTION
We've had a lot of spam recently that included invites to other Discord servers.

The spam is using invites of the form `discord.gg/foo`, without the `https://`. Discord treats this as an invite link, but it doesn't trigger the link detection in the bot.

The existing checks for duplicate messages get triggered eventually, but this PR adds an explicit check for `discord.gg/` and triggers the logging/blocking quicker for those messages.