### PR TITLE
Update the instructions in the jobs channel

### DIFF
--- a/src/features/instruction-message.ts
+++ b/src/features/instruction-message.ts
@@ -86,7 +86,7 @@ const handlers = [
   ),
   createInstructionMessage(
     'jobs',
-    ':pushpin: Please read [the pinned message](https://discord.com/channels/325477692906536972/325675277046906881/938461542775685140) before posting in this channel'
+    'Messages in this channel are posted automatically from <https://vuejobs.com/>'
   ),
   createInstructionMessage(
     'pinia',


### PR DESCRIPTION
This instruction message in the `jobs` channel changed a long time ago, when we limited it to just automatic posts.