### PR TITLE
Mitigate the 'spoiler hack'

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -68,3 +68,14 @@ export function isNormalUserMessage(
     (type === MessageType.Default || type === MessageType.Reply)
   )
 }
+
+// The spoiler hack hides parts of a message:
+// - https://www.reddit.com/r/discordapp/comments/uiohaz/someone_managed_to_ping_me_and_other_people_with/
+// It is used by spammers to hide invites or tags at the end of a message.
+// We need to remove it from any messages posted by the bot.
+export function replaceSpoilerHack(
+  messageContent: string | null,
+  replacement = '[...]'
+) {
+  return (messageContent ?? '').replace(/(\|\|\u200b\|\|)+/g, replacement)
+}

--- a/src/features/deleted-message-log.ts
+++ b/src/features/deleted-message-log.ts
@@ -2,7 +2,7 @@ import { EmbedBuilder, Message, PartialMessage } from 'discord.js'
 import { fetchLogChannel, useThread } from '../api/channels'
 import { Bot } from '../core/bot'
 import { events } from '../core/feature'
-import { logger } from '../core/utils'
+import { logger, replaceSpoilerHack } from '../core/utils'
 
 export default events({
   async messageDelete(bot, message) {
@@ -53,11 +53,14 @@ const logDeletedMessages = async (
 
     embed.setDescription(`
       **Message from <@${author?.id}> deleted in** <#${message.channel.id}>
-      ${message.content}
+      ${replaceSpoilerHack(message.content)}
     `)
   } else {
     const joinedMessages = messages
-      .map(message => `[<@${message.author?.id}>]: ${message.content}`)
+      .map(
+        message =>
+          `[<@${message.author?.id}>]: ${replaceSpoilerHack(message.content)}`
+      )
       .join('\n')
 
     embed.setDescription(`


### PR DESCRIPTION
We've had a lot of spam recently that uses the 'spoiler hack' to hide parts of the message:

https://www.reddit.com/r/discordapp/comments/uiohaz/someone_managed_to_ping_me_and_other_people_with/

The hack allows parts of the message to be hidden. Spammers use it to hide pings and invites in their messages.

The spam detection wasn't tricked, but it did make some of the log messages confusing. The logged message contains the original message, including the hack, so the pings/invites weren't visible in the log.

This change detects the spoiler hack and uses it as a spam indicator. It also removes the spoilers from the log messages so the end of the message is shown in the log.