### PR TITLE
Fix archived threads in statistics

### DIFF
--- a/src/api/channels.ts
+++ b/src/api/channels.ts
@@ -11,7 +11,7 @@ import {
   MessageableGuildChannel,
   ThreadableGuildChannel
 } from './types/channels'
-import { MessageFilteringOptions } from './types/message-filtering-options'
+import { DateFilteringOptions } from './types/date-filtering-options'
 import { isDeleted } from './deletion-cache'
 import { Bot } from '../core/bot'
 import { getDateString, getFilteringDateString, pause } from '../core/utils'
@@ -153,7 +153,7 @@ export async function useThread(
 const createDateChecks = ({
   startDay = 0,
   endDay = 0
-}: MessageFilteringOptions) => {
+}: DateFilteringOptions) => {
   const earliestDate = getFilteringDateString(startDay)
   const latestDate = getFilteringDateString(endDay)
 
@@ -178,7 +178,7 @@ const createDateChecks = ({
 
 export async function* loadThreadsFor(
   channel: ThreadableGuildChannel,
-  filteringOptions: MessageFilteringOptions = {}
+  filteringOptions: DateFilteringOptions = {}
 ) {
   const { isTooOld, isInDateRange } = createDateChecks(filteringOptions)
 

--- a/src/api/channels.ts
+++ b/src/api/channels.ts
@@ -1,5 +1,7 @@
 import {
+  AnyThreadChannel,
   ChannelType,
+  FetchArchivedThreadOptions,
   NonThreadGuildBasedChannel,
   TextChannel,
   ThreadAutoArchiveDuration,
@@ -9,8 +11,10 @@ import {
   MessageableGuildChannel,
   ThreadableGuildChannel
 } from './types/channels'
+import { MessageFilteringOptions } from './types/message-filtering-options'
 import { isDeleted } from './deletion-cache'
 import { Bot } from '../core/bot'
+import { getDateString, getFilteringDateString, pause } from '../core/utils'
 
 export async function fetchLogChannel(bot: Bot): Promise<TextChannel> {
   const logChannelId = bot.config.LOG_CHANNEL_ID
@@ -144,4 +148,87 @@ export async function useThread(
   }
 
   return thread
+}
+
+const createDateChecks = ({
+  startDay = 0,
+  endDay = 0
+}: MessageFilteringOptions) => {
+  const earliestDate = getFilteringDateString(startDay)
+  const latestDate = getFilteringDateString(endDay)
+
+  // We don't necessarily have access to the messages, so we approximate with the timestamps. Anything using these
+  // threads will need to check the messages to confirm whether they are in the date range.
+  const isTooOld = (thread: AnyThreadChannel) =>
+    thread.archiveTimestamp &&
+    getDateString(thread.archiveTimestamp) < earliestDate
+  const isTooNew = (thread: AnyThreadChannel) =>
+    thread.createdTimestamp &&
+    getDateString(thread.createdTimestamp) > latestDate
+
+  const isInDateRange = (thread: AnyThreadChannel) =>
+    !isTooNew(thread) && !isTooOld(thread)
+
+  return {
+    isTooOld,
+    isTooNew,
+    isInDateRange
+  }
+}
+
+export async function* loadThreadsFor(
+  channel: ThreadableGuildChannel,
+  filteringOptions: MessageFilteringOptions = {}
+) {
+  const { isTooOld, isInDateRange } = createDateChecks(filteringOptions)
+
+  // Active threads can all be loaded in a single call
+  const activeThreads = await channel.threads.fetchActive()
+
+  for (const thread of activeThreads.threads.values()) {
+    if (isInDateRange(thread)) {
+      yield thread
+    }
+  }
+
+  let lastThread: AnyThreadChannel | null | undefined = null
+  let queryCount = 1000
+
+  // Archived threads are paged, so we load the pages in a loop
+  while (true) {
+    const params: FetchArchivedThreadOptions = {
+      limit: 100
+    }
+
+    if (lastThread !== null) {
+      params.before = lastThread
+    }
+
+    const pageOfThreads = await channel.threads.fetchArchived(params)
+
+    for (const thread of pageOfThreads.threads.values()) {
+      if (isInDateRange(thread)) {
+        yield thread
+      }
+    }
+
+    lastThread = pageOfThreads.threads.last()
+
+    if (!pageOfThreads.hasMore || !lastThread || isTooOld(lastThread)) {
+      break
+    }
+
+    --queryCount
+
+    if (queryCount === 0) {
+      throw new Error(
+        `Too many queries, aborting. Channel ${channel.id}, ${JSON.stringify(
+          filteringOptions
+        )}`
+      )
+    }
+
+    // Wait for 50ms between queries to avoid hitting a rate limit
+    await pause(50)
+  }
 }

--- a/src/api/messages.ts
+++ b/src/api/messages.ts
@@ -5,7 +5,7 @@ import {
   ThreadChannel
 } from 'discord.js'
 import { MessageableGuildChannel } from './types/channels'
-import { MessageFilteringOptions } from './types/message-filtering-options'
+import { DateFilteringOptions } from './types/date-filtering-options'
 import { getDateString, getFilteringDateString, pause } from '../core/utils'
 
 const PAGE_SIZE = 100
@@ -13,7 +13,7 @@ const PAGE_SIZE = 100
 const createDateChecks = ({
   startDay = 0,
   endDay = 0
-}: MessageFilteringOptions) => {
+}: DateFilteringOptions) => {
   const earliestDate = getFilteringDateString(startDay)
   const latestDate = getFilteringDateString(endDay)
 
@@ -34,7 +34,7 @@ const createDateChecks = ({
 
 export async function* loadMessagesFor(
   channel: MessageableGuildChannel | ThreadChannel,
-  filteringOptions: MessageFilteringOptions = {}
+  filteringOptions: DateFilteringOptions = {}
 ) {
   const { isTooOld, isInDateRange } = createDateChecks(filteringOptions)
 

--- a/src/api/statistics.ts
+++ b/src/api/statistics.ts
@@ -3,7 +3,7 @@ import {
   MessageableGuildChannel,
   ThreadableGuildChannel
 } from './types/channels'
-import { MessageFilteringOptions } from './types/message-filtering-options'
+import { DateFilteringOptions } from './types/date-filtering-options'
 import {
   fetchLogChannel,
   loadMessageableChannels,
@@ -81,7 +81,7 @@ export async function postCountsAsRanking(
 
 export async function loadMessageStatistics(
   bot: Bot,
-  filteringOptions: MessageFilteringOptions
+  filteringOptions: DateFilteringOptions
 ) {
   const messageableChannels = await loadMessageableChannels(bot)
   const threadableChannels = await loadThreadableChannels(bot)

--- a/src/api/types/date-filtering-options.ts
+++ b/src/api/types/date-filtering-options.ts
@@ -9,7 +9,7 @@
 // "2021-10-12"               - 2021-10-12
 // Date.now()                 - today
 // new Date()                 - today
-export interface MessageFilteringOptions {
+export interface DateFilteringOptions {
   startDay?: number | string | Date
   endDay?: number | string | Date
 }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -68,3 +68,40 @@ export function isNormalUserMessage(
     (type === MessageType.Default || type === MessageType.Reply)
   )
 }
+
+// This may look complicated, but it just checks that the string is plausibly a date in the correct format. It's
+// intended to protect against mistakes during development.
+const DATE_STRING_RE = /^(2\d\d\d-[01]\d-[0123]\d)(?:$|T)/
+
+export const getDateString = (timestamp: string | number | Date) => {
+  let normalizedTimestamp = timestamp
+
+  if (typeof normalizedTimestamp === 'number') {
+    normalizedTimestamp = new Date(normalizedTimestamp)
+  }
+
+  if (normalizedTimestamp instanceof Date) {
+    normalizedTimestamp = normalizedTimestamp.toISOString()
+  }
+
+  const dateStringMatch = normalizedTimestamp.match(DATE_STRING_RE)
+
+  if (dateStringMatch) {
+    return dateStringMatch[1]
+  }
+
+  throw new Error(
+    `Could not parse date string for ${typeof timestamp} ${timestamp}`
+  )
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+export function getFilteringDateString(day: string | number | Date) {
+  // Treat numbers 0 or below as day offsets, rather than epoch times
+  if (typeof day === 'number' && day <= 0) {
+    day = Date.now() + day * MS_PER_DAY
+  }
+
+  return getDateString(day)
+}

--- a/src/features/statistics.ts
+++ b/src/features/statistics.ts
@@ -1,6 +1,6 @@
 import { loadMessageStatistics, postCountsAsRanking } from '../api/statistics'
 import { tasks } from '../core/feature'
-import { logger } from '../core/utils'
+import { getFilteringDateString, logger } from '../core/utils'
 
 // This task generates statistics once per week and posts them to the configured channel
 export default tasks({
@@ -9,26 +9,28 @@ export default tasks({
   interval: 'weekly',
 
   action: async bot => {
-    logger.info('Starting weekly statistics generation...')
-
     // Generates statistics from 28 days ago until yesterday. The range is inclusive.
-    const DAYS = 28
-
-    const { users, channels } = await loadMessageStatistics(bot, {
-      startDay: -DAYS,
+    const range = {
+      startDay: -28,
       endDay: -1
-    })
+    }
+
+    const startDate = getFilteringDateString(range.startDay)
+    const endDate = getFilteringDateString(range.endDay)
+    const days = range.endDay - range.startDay + 1
+
+    const rangeString = `${startDate} to ${endDate} (${days} days)`
+
+    logger.info(`Starting weekly statistics generation for ${rangeString}...`)
+
+    const { users, channels } = await loadMessageStatistics(bot, range)
 
     await postCountsAsRanking(
       bot,
-      `Posts per channel for the last ${DAYS} days`,
+      `Posts per channel for ${rangeString}`,
       channels
     )
-    await postCountsAsRanking(
-      bot,
-      `Posts per user for the last ${DAYS} days`,
-      users
-    )
+    await postCountsAsRanking(bot, `Posts per user for ${rangeString}`, users)
 
     logger.info('Successfully completed weekly statistics generation')
   }


### PR DESCRIPTION
While attempting to generate statistics for the whole of 2023, I noticed that the counts for `help-forum` and `pinia` were far too low.

The problem is the archived threads. By default only the most recent 50 are loaded per channel. That can be increased to 100, but beyond that it requires paging to load them.

For monthly stats this hadn't been a problem, as we usually don't have more than 50 archived threads with recent enough messages. But for yearly stats it accounted for most of the messages in those channels.

Active threads don't require paging and can be loaded in one call.

`channels.ts` now has `loadThreadsFor`, which is written in a similar style to `loadMessagesFor` in `messages.ts`.

The date-related stuff from `messages.ts` has been migrated to `utils.ts`, and `MessageFilteringOptions` has been renamed to `DateFilteringOptions`. These are now also used by `channels.ts`.

The changes to `features/statistics.ts` are just updates to the log messages. Those aren't directly related to the threads problem, but they were also motivated by struggling to generate yearly stats. The key change is that it now explicitly logs the start and end date, making it easier to verify that it is using the correct date range.