### PR TITLE
Update static messages

### DIFF
--- a/src/assets/how-to-get-help.md
+++ b/src/assets/how-to-get-help.md
@@ -110,6 +110,20 @@ Try to be realistic when asking a question. Questions that need an experienced d
 
 ---
 
+## Pings
+
+Do not use `@` mentions to ping people who are not already actively involved in solving your current problem.
+
+Likewise, don't use replies to old messages or unrelated conversations just to get someone's attention.
+
+Answering questions is a collaborative effort. You shouldn't target individuals when asking a question. In particular, don't ping library maintainers or people who have been helpful in the past.
+
+You won't be able to use `@everyone` or `@here` pings, but you shouldn't be trying to use them anyway.
+
+You will find that people are unwilling to help you if you abuse pings. You may also be banned from the server.
+
+---
+
 ## Other advice
 
 :one: Try to wait for a channel to go quiet before posting your question. If you ask in the middle of another conversation your question may just get lost.

--- a/src/assets/how-to-get-help.md
+++ b/src/assets/how-to-get-help.md
@@ -47,7 +47,7 @@ You should research your question before you ask. Search the web and read the re
 
 ---
 
-We aren't mind readers :brain:. A good question needs to make it clear what the problem is. We don't know what your application does or what you're expecting your code to do. Never describe the problem as 'it doesn't work'. Explain what you're trying to do and what is happening instead.
+We aren't mind readers :brain:. A good question needs to make it clear what the problem is. We don't know what your application does or what you're expecting your code to do. Never describe the problem as 'it doesn't work'. Explain what you're trying to do, what you're expecting to happen and what is happening instead.
 
 ---
 
@@ -112,14 +112,14 @@ Try to be realistic when asking a question. Questions that need an experienced d
 
 ## Other advice
 
-:one: Never `@` tag people unless they are already involved in answering your question.
-:two: The people helping you will usually be typing code directly into Discord. They probably haven't run it. Don't expect it to work perfectly. You need to study it and understand it, not just copy it.
-:three: Try to wait for a channel to go quiet before posting your question. If you ask in the middle of another conversation your question may just get lost.
-:four: Don't describe your question as 'urgent' or 'important' or anything else that implies your question should be given higher priority. You'll generally find that people are less likely to help you if you demand immediate assistance.
-:five: Don't post questions just before you need to rush off. Most questions will need further input from you before reaching a final answer.
-:six: Try to avoid asking questions when you're tired and/or frustrated. Give yourself time to calm down or come back to the problem after some sleep. The help channels are not the right place to vent your frustrations.
-:seven: If your question goes unanswered for several hours then feel free to bump it. Post a 'reply' to the original post, politely asking whether anyone is able to help. A question can easily get lost if there are lots of other questions being asked. Please be patient and don't keep asking the same question over and over again. If no-one is answering then it could be that your question isn't clear, or perhaps it's just that nobody knows the answer.
-:eight: Try to keep all conversations in the public channels rather than using DMs. DMs prevent other people from helping. You are more likely to receive bad advice or be targeted by a scammer if you use DMs.
+:one: Try to wait for a channel to go quiet before posting your question. If you ask in the middle of another conversation your question may just get lost.
+:two: Don't describe your question as 'urgent' or 'important' or anything else that implies your question should be given higher priority. You'll generally find that people are less likely to help you if you demand immediate assistance.
+:three: Try to ask the whole question in one go, rather than splitting it up into lots of short messages. Posting separate messages saying 'Hello' or 'I have a question' just disrupts other conversations without providing any meaningful information about your own question.
+:four: Don't post questions just before you need to rush off. Most questions will need further input from you before reaching a final answer.
+:five: Try to avoid asking questions when you're tired and/or frustrated. Give yourself time to calm down or come back to the problem after some sleep. The help channels are not the right place to vent your frustrations.
+:six: If your question goes unanswered for several hours then feel free to bump it. Post a 'reply' to the original post, politely asking whether anyone is able to help. A question can easily get lost if there are lots of other questions being asked. Please be patient and don't keep asking the same question over and over again. If no-one is answering then it could be that your question isn't clear, or perhaps it's just that nobody knows the answer.
+:seven: Try to keep all conversations in the public channels rather than using DMs. DMs prevent other people from helping. You are more likely to receive bad advice or be targeted by a scammer if you use DMs.
+:eight: The people helping you will usually be typing code directly into Discord. They probably haven't run it. Don't expect it to work perfectly. You need to study it and understand it, not just copy it.
 
 ---
 

--- a/src/assets/related-discords.md
+++ b/src/assets/related-discords.md
@@ -1,6 +1,7 @@
 ## General Vue
 
 Vue Land: <https://chat.vuejs.org/>
+Anthony Fu:  <https://chat.antfu.me/>
 Egoist OSS: <https://discord.gg/2t5mdCz>
 VueJobs: <https://discord.gg/kVqcTzj>
 VueMastery: <https://discord.gg/6BhB5bZ>
@@ -23,25 +24,21 @@ Ark UI / Zag.js: <https://zagjs.com/discord>
 Bootstrap-Vue: <https://discord.com/invite/B8pcyCd>
 Buefy: <https://discordapp.com/invite/ZkdFJMr>
 Chakra UI: <https://discord.gg/jvsvfQSjhv>
-Element UI: <https://gitter.im/ElemeFE/element>
 Inkline: <https://discord.gg/v7RbKcTSjQ>
-Iview: <https://gitter.im/iview/iview>
 Naive UI: <https://discord.gg/Pqv7Mev5Dd>
 Oruga UI: <https://discord.gg/9kPxPUXzRZ>
 PrimeVue: <https://discord.gg/gzKFYnpmCY>
 Quasar: <https://discord.gg/3yd2hUd>
 StoreFront UI: <https://discord.com/invite/TJpdzzN6q5>
-Vue Material: <https://discord.gg/CyfB6hC>
-VueSax: <https://discord.gg/2kHwpfe>
-Vuetify: <https://discord.gg/m9jP5vy>
+Vuetify: <https://community.vuetifyjs.com/>
 
 ---
 
 ## Other libraries
 
 FormKit: <https://discord.gg/2q3UZkUQbR>
+TanStack: <https://discord.gg/WrRKjPJ>
 Vue Flow: <https://discord.gg/rwt6CBk4b5>
-Vue Formulate: <https://discord.gg/NTYTVm5yFp>
 
 ---
 
@@ -69,6 +66,7 @@ Nodeiflux: <https://discord.gg/vUsrbjd>
 AlphaBet: <https://discord.gg/zVg5Xjk>
 Devcord: <https://discord.gg/devcord>
 freeCodeCamp: <https://discord.gg/KVUmVXA>
+The Programmer's Hangout: <https://discord.gg/programming>
 UX/UI: <https://discord.gg/2uSraS9>
 Webdev / Webdesign: <https://discord.gg/web>
 World of Coding: <https://discord.gg/program>
@@ -80,7 +78,6 @@ World of Coding: <https://discord.gg/program>
 Alpine: <https://discord.com/invite/jUtkPyT>
 Angular: <https://discord.gg/angular>
 Ember: <https://discord.gg/emberjs>
-Gatsby: <https://discord.gg/5tdtA9k>
 Reactiflux: <https://discord.gg/gtan9Ju>
 Solid: <https://discord.com/invite/solidjs>
 Svelte: <https://discord.gg/H87FfaS>
@@ -89,10 +86,8 @@ Svelte: <https://discord.gg/H87FfaS>
 
 ## CSS
 
-Bootstrap: <https://spectrum.chat/bootstrap>
 Tailwind: <https://discord.gg/vRmXppU>
 UIKit: <https://discord.gg/NEt4Pv7>
-Windi CSS: <https://discord.gg/YHVBncpN5g>
 
 ---
 
@@ -100,6 +95,7 @@ Windi CSS: <https://discord.gg/YHVBncpN5g>
 
 Adonis: <https://discord.gg/k5myGAz>
 Elixir: <https://discord.gg/elixir>
+Feathers: <https://discord.gg/qa8kez8QBx>
 Laravel: <https://discord.gg/E6EKnWS>
 Meteor: <https://discord.gg/255GbrZ>
 Nest: <https://discord.gg/G7Qnnhy>
@@ -130,14 +126,13 @@ Supabase: <https://discord.supabase.com/>
 Flutter: <https://discord.gg/N7Yshp4>
 NativeScript: <https://nativescript.org/discord>
 Tauri: <https://discord.gg/KwA62Jh>
-Weex EN: <https://gitter.im/weex-en/Lobby>
 
 ---
 
 ## GraphQL
 
-Apollo: <https://spectrum.chat/apollo>
-GraphQL: <https://discord.gg/ef2h6QM>
+Apollo: <https://discord.gg/graphos>
+GraphQL: <https://discord.graphql.org/>
 HasuraHQ: <https://discord.gg/vBPpJkS>
 Relay: <https://discord.gg/Kb3SFkUeQt>
 

--- a/src/assets/related-discords.md
+++ b/src/assets/related-discords.md
@@ -8,20 +8,18 @@ Vuejs Developers: <https://www.facebook.com/groups/vuejsdevelopers>
 
 ---
 
-## Boilerplates
+## Vue meta-frameworks
 
-Gridsome: <https://discord.gg/22ysRd3>
 Ionic: <https://ionic.link/discord>
 Nuxt: <https://discord.gg/Y6HGQeP>
 Quasar: <https://discord.gg/3yd2hUd>
-Saber: <https://discordapp.com/invite/22TBk7H>
-VueFront: <https://discord.gg/C9vcTCQ>
 Vue-Storefront: <https://discord.vuestorefront.io/>
 
 ---
 
 ## UI libraries
 
+Ark UI / Zag.js: <https://zagjs.com/discord>
 Bootstrap-Vue: <https://discord.com/invite/B8pcyCd>
 Buefy: <https://discordapp.com/invite/ZkdFJMr>
 Chakra UI: <https://discord.gg/jvsvfQSjhv>
@@ -31,6 +29,7 @@ Iview: <https://gitter.im/iview/iview>
 Naive UI: <https://discord.gg/Pqv7Mev5Dd>
 Oruga UI: <https://discord.gg/9kPxPUXzRZ>
 PrimeVue: <https://discord.gg/gzKFYnpmCY>
+Quasar: <https://discord.gg/3yd2hUd>
 StoreFront UI: <https://discord.com/invite/TJpdzzN6q5>
 Vue Material: <https://discord.gg/CyfB6hC>
 VueSax: <https://discord.gg/2kHwpfe>
@@ -51,7 +50,7 @@ Vue Formulate: <https://discord.gg/NTYTVm5yFp>
 CodeSandbox: <https://discord.gg/5BpufEP7MH>
 Storybook: <https://discord.gg/NzrwbJ5>
 Vite: <https://chat.vitejs.dev/> and <#709030686945968188>
-Volar: <https://discord.gg/d5TqRH8Tya>
+Volar.js Dev: <https://discord.gg/7qfYWRrUAM>
 
 ---
 
@@ -83,6 +82,7 @@ Angular: <https://discord.gg/angular>
 Ember: <https://discord.gg/emberjs>
 Gatsby: <https://discord.gg/5tdtA9k>
 Reactiflux: <https://discord.gg/gtan9Ju>
+Solid: <https://discord.com/invite/solidjs>
 Svelte: <https://discord.gg/H87FfaS>
 
 ---
@@ -163,5 +163,4 @@ Vitest: <https://chat.vitest.dev/>
 ## Local Meetup chats
 
 Berlin: <https://discord.gg/PRK2y2U>
-Kyiv: <https://t.me/vuejs_kyiv>
 Seattle: <https://discord.gg/Wdvr4E9>

--- a/src/assets/rules.md
+++ b/src/assets/rules.md
@@ -3,7 +3,7 @@
 ## Ground rules
 
 :one: Be respectful: <https://vuejs.org/about/coc.html>
-:two: Personal attacks, abuse, bullying, harassment, trolling, hate speech, etc. will not be tolerated
+:two: Personal attacks, threats, abuse, bullying, harassment, trolling, hate speech, etc. will not be tolerated
 :three: No spam. If it looks like spam, it's spam
 :four: Post messages in one channel only - don't cross-post between channels
 :five: Do not use `@` mentions unless you are responding to someone
@@ -16,6 +16,7 @@ You should also read <#854729996312641536> before posting questions.
 
 * Rules :one:, :two: & :three: also apply to DMs
 * Don't use DMs to ask for help with your code: use the public channels
+* Use the public channels when answering questions, not DMs
 * Don't send DMs asking for work
 
 ## Moderation/admin channels


### PR DESCRIPTION
Updates to `how-to-get-help.md`, `related-discords.md` and `rules.md`.

The changes to `related-discords.md` are already live, the others aren't.

The diff for the `Other advice` section of `how-to-get-help.md` is a bit difficult to read:

- Item three is new.
- The old item two has moved to item eight.
- The first item, about not tagging people, has been removed. The other changes pushed the message over the length limit, so I had to cut something, and this is already covered in the `#rules`.

